### PR TITLE
fix: skip signature check if base64PublicKey is null

### DIFF
--- a/library/src/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -337,7 +337,15 @@ public class BillingProcessor extends BillingBase {
 
 	private boolean verifyPurchaseSignature(String productId, String purchaseData, String dataSignature) {
         try {
-            return Security.verifyPurchase(productId, signatureBase64, purchaseData, dataSignature);
+            /*
+             * Skip the signature check if the provided License Key is NULL and return true in order to
+             * continue the purchase flow
+             */
+            if (TextUtils.isEmpty(signatureBase64)) {
+                return true;
+            } else {
+                return Security.verifyPurchase(productId, signatureBase64, purchaseData, dataSignature);
+            }
         } catch (Exception e) {
             return false;
         }

--- a/library/src/com/anjlab/android/iab/v3/Security.java
+++ b/library/src/com/anjlab/android/iab/v3/Security.java
@@ -54,9 +54,6 @@ class Security {
      * @param signature the signature for the data, signed with the private key
      */
     public static boolean verifyPurchase(String productId, String base64PublicKey, String signedData, String signature) {
-        if (base64PublicKey == null) {
-            return true;
-        }
         if (TextUtils.isEmpty(signedData) || TextUtils.isEmpty(base64PublicKey) ||
                 TextUtils.isEmpty(signature)) {
 

--- a/library/src/com/anjlab/android/iab/v3/Security.java
+++ b/library/src/com/anjlab/android/iab/v3/Security.java
@@ -47,22 +47,22 @@ class Security {
      * Verifies that the data was signed with the given signature, and returns
      * the verified purchase. The data is in JSON format and signed
      * with a private key. The data also contains the {@link PurchaseState}
-     * and product ID of the purchase.
+     * and product ID of the purchase. The purchase verification will be skipped
+     * if the base64PublicKey is NULL.
      * @param productId the product Id used for debug validation.
      * @param base64PublicKey the base64-encoded public key to use for verifying.
      * @param signedData the signed JSON string (signed, not encrypted)
      * @param signature the signature for the data, signed with the private key
      */
     public static boolean verifyPurchase(String productId, String base64PublicKey, String signedData, String signature) {
-        if (base64PublicKey == null) {
+        if (TextUtils.isEmpty(base64PublicKey)) {
             return true;
-        }
-        if (TextUtils.isEmpty(signedData) || TextUtils.isEmpty(base64PublicKey) ||
-                TextUtils.isEmpty(signature)) {
-
-            if(BuildConfig.DEBUG){
-                //handle test purchase not having signature
-                if(productId.equals("android.test.purchased") && TextUtils.isEmpty(signature)){
+        } else if (TextUtils.isEmpty(signedData)
+                || TextUtils.isEmpty(signature)) {
+            if (BuildConfig.DEBUG) {
+                // handle test purchase not having signature
+                if (productId.equals("android.test.purchased")
+                        && TextUtils.isEmpty(signature)) {
                     return true;
                 }
             }

--- a/library/src/com/anjlab/android/iab/v3/Security.java
+++ b/library/src/com/anjlab/android/iab/v3/Security.java
@@ -47,22 +47,22 @@ class Security {
      * Verifies that the data was signed with the given signature, and returns
      * the verified purchase. The data is in JSON format and signed
      * with a private key. The data also contains the {@link PurchaseState}
-     * and product ID of the purchase. The purchase verification will be skipped
-     * if the base64PublicKey is NULL.
+     * and product ID of the purchase.
      * @param productId the product Id used for debug validation.
      * @param base64PublicKey the base64-encoded public key to use for verifying.
      * @param signedData the signed JSON string (signed, not encrypted)
      * @param signature the signature for the data, signed with the private key
      */
     public static boolean verifyPurchase(String productId, String base64PublicKey, String signedData, String signature) {
-        if (TextUtils.isEmpty(base64PublicKey)) {
+        if (base64PublicKey == null) {
             return true;
-        } else if (TextUtils.isEmpty(signedData)
-                || TextUtils.isEmpty(signature)) {
-            if (BuildConfig.DEBUG) {
-                // handle test purchase not having signature
-                if (productId.equals("android.test.purchased")
-                        && TextUtils.isEmpty(signature)) {
+        }
+        if (TextUtils.isEmpty(signedData) || TextUtils.isEmpty(base64PublicKey) ||
+                TextUtils.isEmpty(signature)) {
+
+            if(BuildConfig.DEBUG){
+                //handle test purchase not having signature
+                if(productId.equals("android.test.purchased") && TextUtils.isEmpty(signature)){
                     return true;
                 }
             }

--- a/library/src/com/anjlab/android/iab/v3/Security.java
+++ b/library/src/com/anjlab/android/iab/v3/Security.java
@@ -54,6 +54,9 @@ class Security {
      * @param signature the signature for the data, signed with the private key
      */
     public static boolean verifyPurchase(String productId, String base64PublicKey, String signedData, String signature) {
+        if (base64PublicKey == null) {
+            return true;
+        }
         if (TextUtils.isEmpty(signedData) || TextUtils.isEmpty(base64PublicKey) ||
                 TextUtils.isEmpty(signature)) {
 


### PR DESCRIPTION
If the license key is NULL the signature check is skipped (as stated in the readme file "You can pass NULL if you would like to skip this check")