### PR TITLE
BillingProcessor: prevent null pointer exception at handleActivityResult

### DIFF
--- a/library/src/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -294,6 +294,10 @@ public class BillingProcessor extends BillingBase {
 	public boolean handleActivityResult(int requestCode, int resultCode, Intent data) {
 		if (requestCode != PURCHASE_FLOW_REQUEST_CODE)
 			return false;
+		if (data == null) {
+			Log.e(LOG_TAG, "handleActivityResult: data is null!");
+			return false;
+		}
 		int responseCode = data.getIntExtra(Constants.RESPONSE_CODE, Constants.BILLING_RESPONSE_RESULT_OK);
 		Log.d(LOG_TAG, String.format("resultCode = %d, responseCode = %d", resultCode, responseCode));
 		String purchasePayload = getPurchasePayload();


### PR DESCRIPTION
  * passed in data may be null and will crash when checking extras

java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=2061984, result=0, data=null} to activity
....
Caused by: java.lang.NullPointerException
at com.anjlab.android.iab.v3.BillingProcessor.handleActivityResult(BillingProcessor.java:297)

Change-Id: Idbd1eaed2c2c97d7aee710f16056221461616b22