### PR TITLE
Allow all signatures when testing with static responses

### DIFF
--- a/library/src/com/anjlab/android/iab/v3/Security.java
+++ b/library/src/com/anjlab/android/iab/v3/Security.java
@@ -59,7 +59,7 @@ class Security {
 
             if(BuildConfig.DEBUG){
                 //handle test purchase not having signature
-                if(productId.equals("android.test.purchased") && TextUtils.isEmpty(signature)){
+                if(productId.equals("android.test.purchased")) {
                     return true;
                 }
             }


### PR DESCRIPTION
This will allow you to test your app with random keys when using the reserved product ID android.test.purchased.
I don't see a reason to limit testing static responses with an empty key. This can cause confusion as it leads to unexpected results when using a signature key and the reserved ID android.test.purchased.

Moreover Google explicitely mentions the ability to use static responses as a way to test signature verification.
"In some cases, the JSON string is signed and the response includes the signature so you can test your signature verification implementation using these responses."
http://developer.android.com/google/play/billing/billing_testing.html#billing-testing-static