### PR TITLE
Error handling, equals and hashcode

### DIFF
--- a/library/src/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -227,6 +227,8 @@ public class BillingProcessor extends BillingBase {
 			return true;
 		} catch (Exception e) {
 			Log.e(LOG_TAG, e.toString());
+			if (eventHandler != null)
+				eventHandler.onBillingError(Constants.BILLING_ERROR_OTHER_ERROR, e);
 		}
 		return false;
 	}
@@ -287,6 +289,8 @@ public class BillingProcessor extends BillingBase {
 			}
 		} catch (Exception e) {
 			Log.e(LOG_TAG, e.toString());
+			if (eventHandler != null)
+				eventHandler.onBillingError(Constants.BILLING_ERROR_CONSUME_FAILED, e);
 		}
 		return false;
 	}
@@ -326,6 +330,8 @@ public class BillingProcessor extends BillingBase {
 				}
 			} catch (Exception e) {
 				Log.e(LOG_TAG, String.format("Failed to call getSkuDetails %s", e.toString()));
+				if (eventHandler != null)
+					eventHandler.onBillingError(Constants.BILLING_ERROR_SKUDETAILS_FAILED, e);
 			}
 		}
 		return null;
@@ -394,7 +400,7 @@ public class BillingProcessor extends BillingBase {
 			} catch (Exception e) {
 				Log.e(LOG_TAG, e.toString());
 				if (eventHandler != null)
-					eventHandler.onBillingError(Constants.BILLING_ERROR_OTHER_ERROR, null);
+					eventHandler.onBillingError(Constants.BILLING_ERROR_OTHER_ERROR, e);
 			}
 		} else {
 			if (eventHandler != null)

--- a/library/src/com/anjlab/android/iab/v3/Constants.java
+++ b/library/src/com/anjlab/android/iab/v3/Constants.java
@@ -56,4 +56,6 @@ public class Constants {
 	public static final int BILLING_ERROR_LOST_CONTEXT = 103;
 	public static final int BILLING_ERROR_INVALID_MERCHANT_ID = 104;
 	public static final int BILLING_ERROR_OTHER_ERROR = 110;
+	public static final int BILLING_ERROR_CONSUME_FAILED = 111;
+	public static final int BILLING_ERROR_SKUDETAILS_FAILED = 112;
 }

--- a/library/src/com/anjlab/android/iab/v3/PurchaseInfo.java
+++ b/library/src/com/anjlab/android/iab/v3/PurchaseInfo.java
@@ -16,6 +16,8 @@
 
 package com.anjlab.android.iab.v3;
 
+import android.util.Log;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -28,6 +30,8 @@ import java.util.Date;
  * a purchase you can find <a href="https://github.com/mgoldsborough/google-play-in-app-billing-verification/blob/master/library/GooglePlay/InAppBilling/GooglePlayResponseValidator.php#L64">here</a>
  */
 public class PurchaseInfo {
+
+    private static final String LOG_TAG = "iabv3.purchaseInfo";
 
     public enum PurchaseState {
         PurchasedSuccessfully, Canceled, Refunded, SubscriptionExpired;
@@ -83,7 +87,7 @@ public class PurchaseInfo {
             data.autoRenewing = json.optBoolean("autoRenewing");
             return data;
         } catch (JSONException e) {
-            e.printStackTrace();
+            Log.e(LOG_TAG, "Failed to parse response data " + e.toString());
             return null;
         }
     }

--- a/library/src/com/anjlab/android/iab/v3/SkuDetails.java
+++ b/library/src/com/anjlab/android/iab/v3/SkuDetails.java
@@ -51,4 +51,23 @@ public class SkuDetails {
 	public String toString() {
 		return String.format("%s: %s(%s) %f in %s (%s)", productId, title, description, priceValue, currency, priceText);
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		SkuDetails that = (SkuDetails) o;
+
+		if (isSubscription != that.isSubscription) return false;
+		return !(productId != null ? !productId.equals(that.productId) : that.productId != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = productId != null ? productId.hashCode() : 0;
+		result = 31 * result + (isSubscription ? 1 : 0);
+		return result;
+	}
 }

--- a/library/src/com/anjlab/android/iab/v3/TransactionDetails.java
+++ b/library/src/com/anjlab/android/iab/v3/TransactionDetails.java
@@ -45,4 +45,20 @@ public class TransactionDetails {
 	public String toString() {
 		return String.format("%s purchased at %s(%s). Token: %s, Signature: %s", productId, purchaseTime, orderId, purchaseToken, purchaseInfo.signature);
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		TransactionDetails details = (TransactionDetails) o;
+
+		return !(orderId != null ? !orderId.equals(details.orderId) : details.orderId != null);
+
+	}
+
+	@Override
+	public int hashCode() {
+		return orderId != null ? orderId.hashCode() : 0;
+	}
 }


### PR DESCRIPTION
-Added equals and hashcode to SkuDetails and TransactionDetails objects. This is required because we need to be able to run .contains on collections of these objects. 
- Added calls to error handler for exception cases that were missing. This allows clients to better cover error cases. 