### PR TITLE
Fix re-subscribe error

### DIFF
--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -198,7 +198,10 @@ public class BillingProcessor extends BillingBase {
 		if (!isInitialized() || TextUtils.isEmpty(productId) || TextUtils.isEmpty(purchaseType))
 			return false;
 		try {
-			String purchasePayload = purchaseType + ":" + UUID.randomUUID().toString();
+			String purchasePayload = purchaseType + ":" + productId;
+			if (!purchaseType.equals(Constants.PRODUCT_TYPE_SUBSCRIPTION)) {
+				purchasePayload += ":" + UUID.randomUUID().toString();
+			}
 			savePurchasePayload(purchasePayload);
 			Bundle bundle = billingService.getBuyIntent(Constants.GOOGLE_API_VERSION, contextPackageName, productId, purchaseType, purchasePayload);
 			if (bundle != null) {


### PR DESCRIPTION
attempted to fix re-subscribe error after canceling a subscription.

The problem was that on subscribe request Google returns an old developer payload, used for previously canceled subscription.
The solution was to made developer payload a bit simpler, but less secure...