### PR TITLE
Check wether iab services are supported or not correctly.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.7.0'
     }
 }


### PR DESCRIPTION
Hi AnjLab, here is the brief explanation why I made those changes.
After having a meeting with google guys I found out that checking for "lab service" as you do [here](https://github.com/anjlab/android-inapp-billing-v3/blob/master/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java#L148-L152) is not really reliable. We have an use case when we have to check first whether the lab is supported or not. Depending on that our payment page will show Iab as a payment option if it's supported.

> Example:

 If the phone does not have sim card your method will return true since it's just checking for the existence of the package name but eventually lab service won't work because there is no sim card installed. 

I know that it's really rear case but we still want to cover it since we have more than 1 million active users worldwide. 

Lastly, I am proposing this flow because it's much more reliable no matter what is the circumstances are. If I need one-time purchase I will check for that, if I need subscription I will check for that. Please give a comment if you have any concern. By the way, great library, keep it up!

