### PR TITLE
Feature/add additional checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,21 @@ Simply call static method `BillingProcessor.isIabServiceAvailable()`:
         // continue
     }
 ```
+Please take a note that calling to `BillingProcessor.isIabServiceAvailable()` (only checks Play Market app installed or not) is not enough because there might be a case when it returns true but still payment won't success. Therefore, it's better to
+call to method `isOnTimePurchaseSupported()` after initializing `BillingProcessor`:
+```java
+    boolean isOneTimePurchaseSupported = billingProcessor.isOnTimePurchaseSupported();
+    if(isOneTimePurchaseSupported) {
+        // launch payment flow
+    }
+```
+or call to method `isSubscriptionUpdateSupported()` for checking update subcription usecase:
+```java
+    boolean isSubsUpdateSupported = billingProcessor.isSubscriptionUpdateSupported();
+    if(isSubsUpdateSupported) {
+        // launch payment flow
+    }
+```
 
 ## Consume Purchased Products
 

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -74,6 +74,7 @@ public class BillingProcessor extends BillingBase {
 	private BillingCache cachedSubscriptions;
 	private IBillingHandler eventHandler;
 	private String developerMerchantId;
+	private boolean isOneTimePurchaseSupported;
 	private boolean isSubsUpdateSupported;
 
 	private class HistoryInitializationTask extends AsyncTask<Void, Void, Boolean>
@@ -231,6 +232,19 @@ public class BillingProcessor extends BillingBase {
 
 	public boolean subscribe(Activity activity, String productId, String developerPayload) {
 		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload);
+	}
+
+	public boolean isOnTimePurchaseSupported(){
+		if (isOneTimePurchaseSupported)
+			return true;
+
+		try {
+			int response = billingService.isBillingSupported(Constants.GOOGLE_API_VERSION, contextPackageName, Constants.PRODUCT_TYPE_MANAGED);
+			isOneTimePurchaseSupported = response == Constants.BILLING_RESPONSE_RESULT_OK;
+		} catch (RemoteException e) {
+			e.printStackTrace();
+		}
+		return isOneTimePurchaseSupported;
 	}
 
 	public boolean isSubscriptionUpdateSupported() {


### PR DESCRIPTION
> @serggl as you asked to create a new branch, hence new PR to have a clean history I've done some changes. Please, have a look at changes.

Hi AnjLab, here is the brief explanation why I made those changes.
After having a meeting with google guys I found out that checking for "lab service" as you do here is not enough. We have an use case when we have to check first whether the lab is supported or not. Depending on that our payment page will show Iab as a payment option if it's supported.

Example:
If the phone does not have sim card your method will return true since it's just checking for the existence of the package name but eventually lab service won't work because there is no sim card installed.

I know that it's really rear case but we still want to cover it since we have more than 1 million active users worldwide.

Lastly, I am proposing to have this extra method to make it more reliable no matter what are the circumstances are. If I need one-time purchase I will check for that, if I need subscription I will check for that. Please give a comment if you have any concern. By the way, great library, keep it up!