### PR TITLE
minor typo

### DIFF
--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -234,7 +234,7 @@ public class BillingProcessor extends BillingBase {
 		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload);
 	}
 
-	public boolean isOnTimePurchaseSupported(){
+	public boolean isOneTimePurchaseSupported(){
 		if (isOneTimePurchasesSupported)
 			return true;
 


### PR DESCRIPTION
Minor type for the function isOneTimePurchaseSupported()

Made it to match the same as the one found in README.