### PR TITLE
Issue 251. Pulled bindPlayServices() out of constructor and into separate initialize() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ public class SomeActivity extends Activity implements BillingProcessor.IBillingH
 		setContentView(R.layout.activity_main);
 
 		bp = new BillingProcessor(this, "YOUR LICENSE KEY FROM GOOGLE PLAY CONSOLE HERE", this);
+		// or bp = BillingProcessor.newBillingProcessor(this, "YOUR LICENSE KEY FROM GOOGLE PLAY CONSOLE HERE", this);
+		// See below on why this is a useful alternative
 	}
 	
 	// IBillingHandler implementation
@@ -102,6 +104,13 @@ bp.subscribe(YOUR_ACTIVITY, "YOUR SUBSCRIPTION ID FROM GOOGLE PLAY CONSOLE HERE"
 		
 		super.onDestroy();
 	}
+```
+
+### Instantiating a `BillingProcessor` with late initialization
+The basic `new BillingProcessor(...)` actually binds to Play Services inside the constructor. This can, very rarely, lead to a race condition where Play Services are bound and `onBillingInitialized()` is called before the constructor finishes, and can lead to NPEs. To avoid this, we have the following:
+```java
+bp = BillingProcessor.newBillingProcessor(this, "YOUR LICENSE KEY FROM GOOGLE PLAY CONSOLE HERE", this); // doesn't bind
+bp.initialize(); // binds
 ```
 
 ## Testing In-app Billing

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -125,6 +125,25 @@ public class BillingProcessor extends BillingBase
 		}
 	};
 
+	/**
+	 * Returns a new {@link BillingProcessor}, without immediately binding to Play Services. If you use
+	 * this factory, then you must call {@link #initialize()} afterwards.
+	 */
+	public static BillingProcessor newBillingProcessor(Context context, String licenseKey, IBillingHandler handler)
+	{
+		return newBillingProcessor(context, licenseKey, null, handler);
+	}
+
+	/**
+	 * Returns a new {@link BillingProcessor}, without immediately binding to Play Services. If you use
+	 * this factory, then you must call {@link #initialize()} afterwards.
+	 */
+	public static BillingProcessor newBillingProcessor(Context context, String licenseKey, String merchantId,
+													   IBillingHandler handler)
+	{
+		return new BillingProcessor(context, licenseKey, merchantId, handler, false);
+	}
+
 	public BillingProcessor(Context context, String licenseKey, IBillingHandler handler)
 	{
 		this(context, licenseKey, null, handler);
@@ -133,6 +152,12 @@ public class BillingProcessor extends BillingBase
 	public BillingProcessor(Context context, String licenseKey, String merchantId,
 							IBillingHandler handler)
 	{
+		this(context, licenseKey, merchantId, handler, true);
+	}
+
+	private BillingProcessor(Context context, String licenseKey, String merchantId, IBillingHandler handler,
+							 boolean bindImmediately)
+	{
 		super(context.getApplicationContext());
 		signatureBase64 = licenseKey;
 		eventHandler = handler;
@@ -140,6 +165,18 @@ public class BillingProcessor extends BillingBase
 		cachedProducts = new BillingCache(getContext(), MANAGED_PRODUCTS_CACHE_KEY);
 		cachedSubscriptions = new BillingCache(getContext(), SUBSCRIPTIONS_CACHE_KEY);
 		developerMerchantId = merchantId;
+		if (bindImmediately)
+		{
+			bindPlayServices();
+		}
+	}
+
+	/**
+	 * Binds to Play Services. When complete, caller will be notified via
+	 * {@link IBillingHandler#onBillingInitialized()}.
+	 */
+	public void initialize()
+	{
 		bindPlayServices();
 	}
 


### PR DESCRIPTION
Code is self-explanatory, but breaking for current users.

**Rationale:**
Sometimes, `bindPlayServices()` finishes its asynchronous work _before_ the constructor finishes. This can mean that `onBillingInitialized()` is called before the constructor finishes, and so work involving a `billingProcessor` can result in NPEs.