### PR TITLE
Throw exception when not initialized for is*Supported

### DIFF
--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -322,6 +322,11 @@ public class BillingProcessor extends BillingBase
 
 	public boolean isOneTimePurchaseSupported()
 	{
+		if (!isInitialized())
+		{
+			throw new IllegalStateException("BillingProcessor is not initialized");
+		}
+
 		if (isOneTimePurchasesSupported)
 		{
 			return true;
@@ -342,6 +347,11 @@ public class BillingProcessor extends BillingBase
 
 	public boolean isSubscriptionUpdateSupported()
 	{
+		if (!isInitialized())
+		{
+			throw new IllegalStateException("BillingProcessor is not initialized");
+		}
+
 		// Avoid calling the service again if this value is true
 		if (isSubsUpdateSupported)
 		{


### PR DESCRIPTION
This PR will change `BillingProcessor` so that it throws an `InvalidStateException` with an appropriate message for `isOneTimePurchaseSupported` and `isSubscriptionUpdateSupported` and avoids a NPE from being thrown. This solves #253