### PR TITLE
Get past history purchases

### DIFF
--- a/library/src/main/aidl/com/android/vending/billing/IInAppBillingService.aidl
+++ b/library/src/main/aidl/com/android/vending/billing/IInAppBillingService.aidl
@@ -189,4 +189,95 @@ interface IInAppBillingService {
      */
     Bundle getBuyIntentToReplaceSkus(int apiVersion, String packageName,
         in List<String> oldSkus, String newSku, String type, String developerPayload);
+
+    /**
+     * Returns a pending intent to launch the purchase flow for an in-app item. This method is
+     * a variant of the {@link #getBuyIntent} method and takes an additional {@code extraParams}
+     * parameter. This parameter is a Bundle of optional keys and values that affect the
+     * operation of the method.
+     * @param apiVersion billing API version that the app is using, must be 6 or later
+     * @param packageName package name of the calling app
+     * @param sku the SKU of the in-app item as published in the developer console
+     * @param type of the in-app item being purchased ("inapp" for one-time purchases
+     *        and "subs" for subscriptions)
+     * @param developerPayload optional argument to be sent back with the purchase information
+     * @extraParams a Bundle with the following optional keys:
+     *        "skusToReplace" - List<String> - an optional list of SKUs that the user is
+     *                          upgrading or downgrading from.
+     *                          Pass this field if the purchase is upgrading or downgrading
+     *                          existing subscriptions.
+     *                          The specified SKUs are replaced with the SKUs that the user is
+     *                          purchasing. Google Play replaces the specified SKUs at the start of
+     *                          the next billing cycle.
+     * "replaceSkusProration" - Boolean - whether the user should be credited for any unused
+     *                          subscription time on the SKUs they are upgrading or downgrading.
+     *                          If you set this field to true, Google Play swaps out the old SKUs
+     *                          and credits the user with the unused value of their subscription
+     *                          time on a pro-rated basis.
+     *                          Google Play applies this credit to the new subscription, and does
+     *                          not begin billing the user for the new subscription until after
+     *                          the credit is used up.
+     *                          If you set this field to false, the user does not receive credit for
+     *                          any unused subscription time and the recurrence date does not
+     *                          change.
+     *                          Default value is true. Ignored if you do not pass skusToReplace.
+     *            "accountId" - String - an optional obfuscated string that is uniquely
+     *                          associated with the user's account in your app.
+     *                          If you pass this value, Google Play can use it to detect irregular
+     *                          activity, such as many devices making purchases on the same
+     *                          account in a short period of time.
+     *                          Do not use the developer ID or the user's Google ID for this field.
+     *                          In addition, this field should not contain the user's ID in
+     *                          cleartext.
+     *                          We recommend that you use a one-way hash to generate a string from
+     *                          the user's ID, and store the hashed string in this field.
+     *                   "vr" - Boolean - an optional flag indicating whether the returned intent
+     *                          should start a VR purchase flow. The apiVersion must also be 7 or
+     *                          later to use this flag.
+     */
+    Bundle getBuyIntentExtraParams(int apiVersion, String packageName, String sku,
+        String type, String developerPayload, in Bundle extraParams);
+
+    /**
+     * Returns the most recent purchase made by the user for each SKU, even if that purchase is
+     * expired, canceled, or consumed.
+     * @param apiVersion billing API version that the app is using, must be 6 or later
+     * @param packageName package name of the calling app
+     * @param type of the in-app items being requested ("inapp" for one-time purchases
+     *        and "subs" for subscriptions)
+     * @param continuationToken to be set as null for the first call, if the number of owned
+     *        skus is too large, a continuationToken is returned in the response bundle.
+     *        This method can be called again with the continuation token to get the next set of
+     *        owned skus.
+     * @param extraParams a Bundle with extra params that would be appended into http request
+     *        query string. Not used at this moment. Reserved for future functionality.
+     * @return Bundle containing the following key-value pairs
+     *         "RESPONSE_CODE" with int value: RESULT_OK(0) if success,
+     *         {@link IabHelper#BILLING_RESPONSE_RESULT_*} response codes on failures.
+     *
+     *         "INAPP_PURCHASE_ITEM_LIST" - ArrayList<String> containing the list of SKUs
+     *         "INAPP_PURCHASE_DATA_LIST" - ArrayList<String> containing the purchase information
+     *         "INAPP_DATA_SIGNATURE_LIST"- ArrayList<String> containing the signatures
+     *                                      of the purchase information
+     *         "INAPP_CONTINUATION_TOKEN" - String containing a continuation token for the
+     *                                      next set of in-app purchases. Only set if the
+     *                                      user has more owned skus than the current list.
+     */
+    Bundle getPurchaseHistory(int apiVersion, String packageName, String type,
+        String continuationToken, in Bundle extraParams);
+
+    /**
+    * This method is a variant of {@link #isBillingSupported}} that takes an additional
+    * {@code extraParams} parameter.
+    * @param apiVersion billing API version that the app is using, must be 7 or later
+    * @param packageName package name of the calling app
+    * @param type of the in-app item being purchased ("inapp" for one-time purchases and "subs"
+    *        for subscriptions)
+    * @param extraParams a Bundle with the following optional keys:
+    *        "vr" - Boolean - an optional flag to indicate whether {link #getBuyIntentExtraParams}
+    *               supports returning a VR purchase flow.
+    * @return RESULT_OK(0) on success and appropriate response code on failures.
+    */
+    int isBillingSupportedExtraParams(int apiVersion, String packageName, String type,
+        in Bundle extraParams);
 }

--- a/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
@@ -19,6 +19,7 @@ public class Constants
 {
 	public static final int GOOGLE_API_VERSION = 3;
 	public static final int GOOGLE_API_SUBSCRIPTION_CHANGE_VERSION = 5;
+    public static final int GOOGLE_API_VERSION_FOR_HISTORY = 6;
 
 	public static final String PRODUCT_TYPE_MANAGED = "inapp";
 	public static final String PRODUCT_TYPE_SUBSCRIPTION = "subs";
@@ -60,6 +61,7 @@ public class Constants
 	public static final String INAPP_PURCHASE_DATA = "INAPP_PURCHASE_DATA";
 	public static final String RESPONSE_INAPP_SIGNATURE = "INAPP_DATA_SIGNATURE";
 	public static final String INAPP_DATA_SIGNATURE_LIST = "INAPP_DATA_SIGNATURE_LIST";
+    public static final String INAPP_CONTINUATION_TOKEN = "INAPP_CONTINUATION_TOKEN";
 	public static final String RESPONSE_ORDER_ID = "orderId";
 	public static final String RESPONSE_PRODUCT_ID = "productId";
 	public static final String RESPONSE_TYPE = "type";
@@ -76,6 +78,8 @@ public class Constants
 	public static final int BILLING_ERROR_LOST_CONTEXT = 103;
 	public static final int BILLING_ERROR_INVALID_MERCHANT_ID = 104;
 	public static final int BILLING_ERROR_INVALID_DEVELOPER_PAYLOAD = 105;
+    public static final int BILLING_ERROR_RECENT_HISTORY_NOT_SUPPORTED = 106;
+    public static final int BILLING_ERROR_NOT_INITIALIZED = 107;
 	public static final int BILLING_ERROR_OTHER_ERROR = 110;
 	public static final int BILLING_ERROR_CONSUME_FAILED = 111;
 	public static final int BILLING_ERROR_SKUDETAILS_FAILED = 112;

--- a/library/src/main/java/com/anjlab/android/iab/v3/HistoryPurchases.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/HistoryPurchases.java
@@ -1,0 +1,39 @@
+package com.anjlab.android.iab.v3;
+
+import java.util.HashMap;
+
+/**
+ * Created by Galeen on 7.6.2017 г..
+ */
+
+public class HistoryPurchases
+{
+    private HashMap<String, PurchaseInfo> inapps, subscriptions;
+
+    public HistoryPurchases(HashMap<String, PurchaseInfo> inapps, HashMap<String, PurchaseInfo> subscriptions)
+    {
+        this.inapps = inapps;
+        this.subscriptions = subscriptions;
+    }
+
+    public HashMap<String, PurchaseInfo> getInapps()
+    {
+        return inapps;
+    }
+
+    public void setInapps(HashMap<String, PurchaseInfo> inapps)
+    {
+        this.inapps = inapps;
+    }
+
+    public HashMap<String, PurchaseInfo> getSubscriptions()
+    {
+        return subscriptions;
+    }
+
+    public void setSubscriptions(HashMap<String, PurchaseInfo> subscriptions)
+    {
+        this.subscriptions = subscriptions;
+    }
+
+}

--- a/library/src/main/java/com/anjlab/android/iab/v3/RecentPurchases.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/RecentPurchases.java
@@ -1,0 +1,39 @@
+package com.anjlab.android.iab.v3;
+
+import java.util.HashMap;
+
+/**
+ * Created by Galeen on 7.6.2017 г..
+ */
+
+public class RecentPurchases
+{
+    private HashMap<String, PurchaseInfo> inapps, subscriptions;
+
+    public RecentPurchases(HashMap<String, PurchaseInfo> inapps, HashMap<String, PurchaseInfo> subscriptions)
+    {
+        this.inapps = inapps;
+        this.subscriptions = subscriptions;
+    }
+
+    public HashMap<String, PurchaseInfo> getInapps()
+    {
+        return inapps;
+    }
+
+    public void setInapps(HashMap<String, PurchaseInfo> inapps)
+    {
+        this.inapps = inapps;
+    }
+
+    public HashMap<String, PurchaseInfo> getSubscriptions()
+    {
+        return subscriptions;
+    }
+
+    public void setSubscriptions(HashMap<String, PurchaseInfo> subscriptions)
+    {
+        this.subscriptions = subscriptions;
+    }
+
+}

--- a/sample/res/layout/activity_main.xml
+++ b/sample/res/layout/activity_main.xml
@@ -118,7 +118,13 @@
                 android:id="@+id/subsDetailsButton"/>
 
         </LinearLayout>
-
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="Past History"
+            android:onClick="onClick"
+            android:id="@+id/pastHistoryButton"/>
     </LinearLayout>
 
 </ScrollView>

--- a/sample/src/com/anjlab/android/iab/v3/sample2/MainActivity.java
+++ b/sample/src/com/anjlab/android/iab/v3/sample2/MainActivity.java
@@ -24,8 +24,13 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.anjlab.android.iab.v3.BillingProcessor;
+import com.anjlab.android.iab.v3.Constants;
+import com.anjlab.android.iab.v3.PurchaseInfo;
+import com.anjlab.android.iab.v3.HistoryPurchases;
 import com.anjlab.android.iab.v3.SkuDetails;
 import com.anjlab.android.iab.v3.TransactionDetails;
+
+import java.util.Map;
 
 public class MainActivity extends Activity {
 	// SAMPLE APP CONSTANTS
@@ -150,6 +155,43 @@ public class MainActivity extends Activity {
 			case R.id.launchMoreButton:
 				startActivity(new Intent(this, MainActivity.class).putExtra(ACTIVITY_NUMBER, getIntent().getIntExtra(ACTIVITY_NUMBER, 1) + 1));
 				break;
+            case R.id.pastHistoryButton:
+                bp.loadHistoryPurchasesFromGoogle(new BillingProcessor.IBillingHistoryHandler() {
+                    @Override
+                    public void onHistoryRestored(HistoryPurchases historyPurchases) {
+                        showToast("Recent history loaded!");
+                        if(historyPurchases.getInapps()!=null){
+                            for (Map.Entry<String, PurchaseInfo> inapp : historyPurchases.getInapps().entrySet())
+                            {
+                                Log.d(LOG_TAG, "Managed Product ID : " + inapp.getKey() + " :\n" +
+                                        inapp.getValue().purchaseData.toString());
+                            }
+                        }
+                        if(historyPurchases.getSubscriptions()!=null){
+                            for (Map.Entry<String, PurchaseInfo> subscription : historyPurchases.getSubscriptions()
+                                    .entrySet())
+                            {
+                                Log.d(LOG_TAG, "Subscription ID : " + subscription.getKey() + " :\n" +
+                                        subscription.getValue().purchaseData.toString());
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void onHistoryError(int errorCode) {
+                        switch (errorCode){
+                            case Constants.BILLING_ERROR_NOT_INITIALIZED :
+                                showToast("Failed to load recent history\n BillingProcessor is not initialized yet");
+                                break;
+                            case Constants.BILLING_ERROR_RECENT_HISTORY_NOT_SUPPORTED :
+                                showToast("Failed to load recent history\nGoogle API < 6");
+                                break;
+                        }
+
+                    }
+                });
+                break;
+
             default:
                 break;
         }


### PR DESCRIPTION
Returns the most recent purchases made by the user for each SKU, even if that purchase is expired, canceled, or consumed.

Because of the note from Android :
Note: The getPurchaseHistory() method has higher overhead than getPurchases(), because it requires a call to the Google Play server. You should use getPurchases() if you do not actually need the user's purchase history.

This request is made in an AsyncTask and IBillingPastHistoryHandler is updated when is done.
Also is not called in onServiceConnected, but only by user's request.

The user is loading the history with loadPastHistoryPurchasesFromGoogle :

    public void  loadPastHistoryPurchasesFromGoogle(IBillingPastHistoryHandler callback) {
        new LoadPastHistoryTask(callback).execute();
    }

There is a new interface just for that call IBillingPastHistoryHandler :

    public interface IBillingPastHistoryHandler {
        void onPastHistoryRestored();
        void onPastHistoryError();
    }

And when the call is done the user can get the history skus from :

    public List<String> listPastHistoryProducts() {
        return cachedProductsPast.getContents();
    }

    public List<String> listPastHistorySubscriptions() {
        return cachedSubscriptionsPast.getContents();
    }

And details from :

    public TransactionDetails getPastPurchaseTransactionDetails(String productId) {
        return getPurchaseTransactionDetails(productId, cachedProductsPast);
    }

    public TransactionDetails getPastSubscriptionTransactionDetails(String productId) {
        return getPurchaseTransactionDetails(productId, cachedSubscriptionsPast);
    }

The minimum Google_API_Version that support this feature is 6.
There is a method to check that too :
public boolean isFullHistorySupported()

I have added in the sample app 1 button to preview the feature :

    bp.loadPastHistoryPurchasesFromGoogle(new     BillingProcessor.IBillingPastHistoryHandler() {
                    @Override
                    public void onPastHistoryRestored() {
                        showToast("Past history loaded!");
                        for (String sku : bp.listPastHistoryProducts()) {
                            TransactionDetails td = bp.getPastPurchaseTransactionDetails(sku);
                            Log.d(LOG_TAG, "Past Managed Product: " + sku + " :\n" + td.toString());
                        }
                        for (String sku : bp.listPastHistorySubscriptions()) {
                            TransactionDetails td = bp.getPastSubscriptionTransactionDetails(sku);
                            Log.d(LOG_TAG, "Past Subscription: " + sku + " :\n" + td.toString());
                        }
                    }

                    @Override
                    public void onPastHistoryError() {
                        showToast("Failed to load past history");
                    }
                });

I have notice that the Play Store is not sending the complete history, but only last event by each item.
I mean, I have tested with one of my applications where my history is a long list, but the service returned only last purchase for each subscription I had. This is a bit disappointing, because I was expecting the ability to follow which months of the year this user were subscribed for example :(

 