### PR TITLE
remove joda dependency that was triggering an `UnsupportedOperationEx…

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -32,7 +32,6 @@ android {
 }
 
 dependencies {
-    compile 'joda-time:joda-time:2.9.9'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support.test:rules:0.5'
 }
@@ -125,7 +124,7 @@ android.libraryVariants.all { variant ->
     task.dependsOn variant.javaCompile
     task.from variant.javaCompile.destinationDir
     task.baseName 'anjlab-iabv3'
-    task.doLast{
+    task.doLast {
         println "Copying jar to sample project..."
         copy {
             from task.archivePath

--- a/library/src/androidTest/java/com/anjlab/android/iab/v3/SkuDetailsParcelableTest.java
+++ b/library/src/androidTest/java/com/anjlab/android/iab/v3/SkuDetailsParcelableTest.java
@@ -14,25 +14,25 @@ public class SkuDetailsParcelableTest
     @Test
     public void testParcelableInApp() throws Exception
     {
-        testParcelable(loadSkuDetails("sku_in_app.json"));
+        testParcelable(loadSkuDetails("sku_in_app.json"), false, false);
     }
 
     @Test
     public void testParcelableSubscription() throws Exception
     {
-        testParcelable(loadSkuDetails("sku_subscription.json"));
+        testParcelable(loadSkuDetails("sku_subscription.json"), false, false);
     }
 
     @Test
     public void testParcelableSubscriptionIntroductory() throws Exception
     {
-        testParcelable(loadSkuDetails("sku_subscription_introductory.json"));
+        testParcelable(loadSkuDetails("sku_subscription_introductory.json"), true, false);
     }
 
     @Test
     public void testParcelableSubscriptionTrial() throws Exception
     {
-        testParcelable(loadSkuDetails("sku_subscription_trial.json"));
+        testParcelable(loadSkuDetails("sku_subscription_trial.json"), false, true);
     }
 
     private SkuDetails loadSkuDetails(String jsonFilePath) throws Exception
@@ -41,7 +41,7 @@ public class SkuDetailsParcelableTest
         return new SkuDetails(details);
     }
 
-    private void testParcelable(SkuDetails skuDetails) throws Exception
+    private void testParcelable(SkuDetails skuDetails, boolean isIntroPrice, boolean isTrial) throws Exception
     {
         Parcel parcel = Parcel.obtain();
 
@@ -61,10 +61,15 @@ public class SkuDetailsParcelableTest
         assertEquals(skuDetails.title, result.title);
         assertEquals(skuDetails.subscriptionPeriod, result.subscriptionPeriod);
         assertEquals(skuDetails.subscriptionFreeTrialPeriod, result.subscriptionFreeTrialPeriod);
+        assertEquals(skuDetails.haveTrialPeriod, result.haveTrialPeriod);
         assertEquals(skuDetails.introductoryPriceValue, result.introductoryPriceValue);
         assertEquals(skuDetails.introductoryPricePeriod, result.introductoryPricePeriod);
         assertEquals(skuDetails.introductoryPriceCycles, result.introductoryPriceCycles);
         assertEquals(skuDetails.introductoryPriceLong, result.introductoryPriceLong);
+        assertEquals(skuDetails.haveIntroductoryPeriod, result.haveIntroductoryPeriod);
         assertEquals(skuDetails.introductoryPriceText, result.introductoryPriceText);
+
+        assertEquals(skuDetails.haveIntroductoryPeriod, isIntroPrice);
+        assertEquals(skuDetails.haveTrialPeriod, isTrial);
     }
 }

--- a/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2014 AnjLab
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,8 +17,6 @@ package com.anjlab.android.iab.v3;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-
-import org.joda.time.Period;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -27,52 +25,48 @@ import java.util.Locale;
 public class SkuDetails implements Parcelable
 {
 
-	public final String productId;
+    public final String productId;
 
-	public final String title;
+    public final String title;
 
-	public final String description;
+    public final String description;
 
-	public final boolean isSubscription;
+    public final boolean isSubscription;
 
-	public final String currency;
+    public final String currency;
 
-	public final Double priceValue;
+    public final Double priceValue;
 
-    public final boolean haveTrialPeriod;
+    public final String subscriptionPeriod;
 
-	public final Period subscriptionPeriod;
+    public final String subscriptionFreeTrialPeriod;
 
-	public final Period subscriptionFreeTrialPeriod;
+    public final double introductoryPriceValue;
 
-    public final boolean haveIntroductoryPeriod;
+    public final String introductoryPricePeriod;
 
-	public final double introductoryPriceValue;
+    public final int introductoryPriceCycles;
 
-	public final Period introductoryPricePeriod;
+    /**
+     * Use this value to return the raw price from the product.
+     * This allows math to be performed without needing to worry about errors
+     * caused by floating point representations of the product's price.
+     * <p>
+     * This is in micros from the Play Store.
+     */
+    public final long priceLong;
 
-	public final int introductoryPriceCycles;
-
-	/**
-	 * Use this value to return the raw price from the product.
-	 * This allows math to be performed without needing to worry about errors
-	 * caused by floating point representations of the product's price.
-	 * <p>
-	 * This is in micros from the Play Store.
-	 */
-	public final long priceLong;
-
-	public final String priceText;
+    public final String priceText;
 
     public final long introductoryPriceLong;
 
     public final String introductoryPriceText;
 
-	public SkuDetails(JSONObject source) throws JSONException
-	{
-		String responseType = source.optString(Constants.RESPONSE_TYPE);
-		if (responseType == null)
-		{
+    public SkuDetails(JSONObject source) throws JSONException
+    {
+        String responseType = source.optString(Constants.RESPONSE_TYPE);
+        if (responseType == null)
+        {
             responseType = Constants.PRODUCT_TYPE_MANAGED;
         }
         productId = source.optString(Constants.RESPONSE_PRODUCT_ID);
@@ -83,72 +77,65 @@ public class SkuDetails implements Parcelable
         priceLong = source.optLong(Constants.RESPONSE_PRICE_MICROS);
         priceValue = priceLong / 1000000d;
         priceText = source.optString(Constants.RESPONSE_PRICE);
-        subscriptionPeriod = parsePeriod(source.optString(Constants.RESPONSE_SUBSCRIPTION_PERIOD, "P"));
-        subscriptionFreeTrialPeriod = parsePeriod(source.optString(Constants.RESPONSE_FREE_TRIAL_PERIOD, "P"));
-        haveTrialPeriod = subscriptionFreeTrialPeriod.toStandardSeconds().getSeconds() != 0;
+        subscriptionPeriod = source.optString(Constants.RESPONSE_SUBSCRIPTION_PERIOD, "P");
+        subscriptionFreeTrialPeriod = source.optString(Constants.RESPONSE_FREE_TRIAL_PERIOD, "P");
         introductoryPriceLong = source.optLong(Constants.RESPONSE_INTRODUCTORY_PRICE_MICROS);
         introductoryPriceValue = introductoryPriceLong / 1000000d;
-        introductoryPriceText = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE, null);
-        introductoryPricePeriod = parsePeriod(source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE_PERIOD, "P"));
-        haveIntroductoryPeriod = introductoryPricePeriod.toStandardSeconds().getSeconds() != 0;
+        introductoryPriceText = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE);
+        introductoryPricePeriod = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE_PERIOD, "P");
         introductoryPriceCycles = source.optInt(Constants.RESPONSE_INTRODUCTORY_PRICE_CYCLES);
     }
 
-	private Period parsePeriod(String iso8601representation)
-	{
-        return Period.parse(iso8601representation);
+    @Override
+    public String toString()
+    {
+        return String.format(Locale.US, "%s: %s(%s) %f in %s (%s)",
+                productId,
+                title,
+                description,
+                priceValue,
+                currency,
+                priceText);
     }
 
-	@Override
-	public String toString()
-	{
-		return String.format(Locale.US, "%s: %s(%s) %f in %s (%s)",
-							 productId,
-							 title,
-							 description,
-							 priceValue,
-							 currency,
-							 priceText);
-	}
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
 
-	@Override
-	public boolean equals(Object o)
-	{
-		if (this == o)
-		{
-			return true;
-		}
-		if (o == null || getClass() != o.getClass())
-		{
-			return false;
-		}
+        SkuDetails that = (SkuDetails) o;
 
-		SkuDetails that = (SkuDetails) o;
+        if (isSubscription != that.isSubscription)
+        {
+            return false;
+        }
+        return !(productId != null ? !productId.equals(that.productId) : that.productId != null);
+    }
 
-		if (isSubscription != that.isSubscription)
-		{
-			return false;
-		}
-		return !(productId != null ? !productId.equals(that.productId) : that.productId != null);
-	}
+    @Override
+    public int hashCode()
+    {
+        int result = productId != null ? productId.hashCode() : 0;
+        result = 31 * result + (isSubscription ? 1 : 0);
+        return result;
+    }
 
-	@Override
-	public int hashCode()
-	{
-		int result = productId != null ? productId.hashCode() : 0;
-		result = 31 * result + (isSubscription ? 1 : 0);
-		return result;
-	}
+    @Override
+    public int describeContents()
+    {
+        return 0;
+    }
 
-	@Override
-	public int describeContents()
-	{
-		return 0;
-	}
-
-	@Override
-	public void writeToParcel(Parcel dest, int flags)
-	{
+    @Override
+    public void writeToParcel(Parcel dest, int flags)
+    {
         dest.writeString(this.productId);
         dest.writeString(this.title);
         dest.writeString(this.description);
@@ -157,19 +144,17 @@ public class SkuDetails implements Parcelable
         dest.writeDouble(this.priceValue);
         dest.writeLong(this.priceLong);
         dest.writeString(this.priceText);
-        dest.writeString(this.subscriptionPeriod.toString());
-        dest.writeString(this.subscriptionFreeTrialPeriod.toString());
-        dest.writeByte(this.haveTrialPeriod ? (byte) 1 : (byte) 0);
+        dest.writeString(this.subscriptionPeriod);
+        dest.writeString(this.subscriptionFreeTrialPeriod);
         dest.writeDouble(this.introductoryPriceValue);
         dest.writeLong(this.introductoryPriceLong);
         dest.writeString(this.introductoryPriceText);
-        dest.writeString(this.introductoryPricePeriod.toString());
-        dest.writeByte(this.haveIntroductoryPeriod ? (byte) 1 : (byte) 0);
+        dest.writeString(this.introductoryPricePeriod);
         dest.writeInt(this.introductoryPriceCycles);
     }
 
-	protected SkuDetails(Parcel in)
-	{
+    protected SkuDetails(Parcel in)
+    {
         this.productId = in.readString();
         this.title = in.readString();
         this.description = in.readString();
@@ -178,28 +163,26 @@ public class SkuDetails implements Parcelable
         this.priceValue = in.readDouble();
         this.priceLong = in.readLong();
         this.priceText = in.readString();
-        this.subscriptionPeriod = parsePeriod(in.readString());
-        this.subscriptionFreeTrialPeriod = parsePeriod(in.readString());
-        this.haveTrialPeriod = in.readByte() != 0;
+        this.subscriptionPeriod = in.readString();
+        this.subscriptionFreeTrialPeriod = in.readString();
         this.introductoryPriceValue = in.readDouble();
         this.introductoryPriceLong = in.readLong();
         this.introductoryPriceText = in.readString();
-        this.introductoryPricePeriod = parsePeriod(in.readString());
-        this.haveIntroductoryPeriod = in.readByte() != 0;
+        this.introductoryPricePeriod = in.readString();
         this.introductoryPriceCycles = in.readInt();
     }
 
-	public static final Parcelable.Creator<SkuDetails> CREATOR =
-			new Parcelable.Creator<SkuDetails>()
-			{
-				public SkuDetails createFromParcel(Parcel source)
-				{
-					return new SkuDetails(source);
-				}
+    public static final Parcelable.Creator<SkuDetails> CREATOR =
+            new Parcelable.Creator<SkuDetails>()
+            {
+                public SkuDetails createFromParcel(Parcel source)
+                {
+                    return new SkuDetails(source);
+                }
 
-				public SkuDetails[] newArray(int size)
-				{
-					return new SkuDetails[size];
-				}
-			};
+                public SkuDetails[] newArray(int size)
+                {
+                    return new SkuDetails[size];
+                }
+            };
 }

--- a/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java
@@ -17,6 +17,7 @@ package com.anjlab.android.iab.v3;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -41,9 +42,13 @@ public class SkuDetails implements Parcelable
 
     public final String subscriptionFreeTrialPeriod;
 
+    public final boolean haveTrialPeriod;
+
     public final double introductoryPriceValue;
 
     public final String introductoryPricePeriod;
+
+    public final boolean haveIntroductoryPeriod;
 
     public final int introductoryPriceCycles;
 
@@ -79,10 +84,12 @@ public class SkuDetails implements Parcelable
         priceText = source.optString(Constants.RESPONSE_PRICE);
         subscriptionPeriod = source.optString(Constants.RESPONSE_SUBSCRIPTION_PERIOD);
         subscriptionFreeTrialPeriod = source.optString(Constants.RESPONSE_FREE_TRIAL_PERIOD);
+        haveTrialPeriod = !TextUtils.isEmpty(subscriptionFreeTrialPeriod);
         introductoryPriceLong = source.optLong(Constants.RESPONSE_INTRODUCTORY_PRICE_MICROS);
         introductoryPriceValue = introductoryPriceLong / 1000000d;
         introductoryPriceText = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE);
         introductoryPricePeriod = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE_PERIOD);
+        haveIntroductoryPeriod = !TextUtils.isEmpty(introductoryPricePeriod);
         introductoryPriceCycles = source.optInt(Constants.RESPONSE_INTRODUCTORY_PRICE_CYCLES);
     }
 
@@ -146,10 +153,12 @@ public class SkuDetails implements Parcelable
         dest.writeString(this.priceText);
         dest.writeString(this.subscriptionPeriod);
         dest.writeString(this.subscriptionFreeTrialPeriod);
+        dest.writeByte(this.haveTrialPeriod ? (byte) 1 : (byte) 0);
         dest.writeDouble(this.introductoryPriceValue);
         dest.writeLong(this.introductoryPriceLong);
         dest.writeString(this.introductoryPriceText);
         dest.writeString(this.introductoryPricePeriod);
+        dest.writeByte(this.haveIntroductoryPeriod ? (byte) 1 : (byte) 0);
         dest.writeInt(this.introductoryPriceCycles);
     }
 
@@ -165,10 +174,12 @@ public class SkuDetails implements Parcelable
         this.priceText = in.readString();
         this.subscriptionPeriod = in.readString();
         this.subscriptionFreeTrialPeriod = in.readString();
+        this.haveTrialPeriod = in.readByte() != 0;
         this.introductoryPriceValue = in.readDouble();
         this.introductoryPriceLong = in.readLong();
         this.introductoryPriceText = in.readString();
         this.introductoryPricePeriod = in.readString();
+        this.haveIntroductoryPeriod = in.readByte() != 0;
         this.introductoryPriceCycles = in.readInt();
     }
 

--- a/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/SkuDetails.java
@@ -77,12 +77,12 @@ public class SkuDetails implements Parcelable
         priceLong = source.optLong(Constants.RESPONSE_PRICE_MICROS);
         priceValue = priceLong / 1000000d;
         priceText = source.optString(Constants.RESPONSE_PRICE);
-        subscriptionPeriod = source.optString(Constants.RESPONSE_SUBSCRIPTION_PERIOD, "P");
-        subscriptionFreeTrialPeriod = source.optString(Constants.RESPONSE_FREE_TRIAL_PERIOD, "P");
+        subscriptionPeriod = source.optString(Constants.RESPONSE_SUBSCRIPTION_PERIOD);
+        subscriptionFreeTrialPeriod = source.optString(Constants.RESPONSE_FREE_TRIAL_PERIOD);
         introductoryPriceLong = source.optLong(Constants.RESPONSE_INTRODUCTORY_PRICE_MICROS);
         introductoryPriceValue = introductoryPriceLong / 1000000d;
         introductoryPriceText = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE);
-        introductoryPricePeriod = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE_PERIOD, "P");
+        introductoryPricePeriod = source.optString(Constants.RESPONSE_INTRODUCTORY_PRICE_PERIOD);
         introductoryPriceCycles = source.optInt(Constants.RESPONSE_INTRODUCTORY_PRICE_CYCLES);
     }
 


### PR DESCRIPTION
- Avoid to use joda dependency since:
1. it's an external dependency that can be incompatible with what other developers use: https://github.com/anjlab/android-inapp-billing-v3/issues/285
2. it leaves the developer the flexibility to use his own formatter
3. for how it is implemented it currently causes a crash `UnsupportedOperationException`
4. for some of us this field is not needed and we can avoid to have this dependency

In general it's a good approach avoiding to add dependencies to libraries whenever possible

- Avoid returning `null` as fallback for `introductoryPriceText`, but rather returns the default to avoid potential crash.