### PR TITLE
Support for getBuyIntentExtraParams()

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ bp.purchase(YOUR_ACTIVITY, "YOUR PRODUCT ID FROM GOOGLE PLAY CONSOLE HERE", "DEV
 bp.subscribe(YOUR_ACTIVITY, "YOUR SUBSCRIPTION ID FROM GOOGLE PLAY CONSOLE HERE", "DEVELOPER PAYLOAD HERE");
 ```
 _IMPORTANT: when you provide a payload, internally the library prepends a string to your payload. For subscriptions, it prepends `"subs:\<productId\>:"`, and for products, it prepends `"inapp:\<productId\>:\<UUID\>:"`. This is important to know if you do any validation on the payload returned from Google Play after a successful purchase._
+
+_With a bundle of extra parameters:_
+
+```java
+Bundle extraParams = new Bundle()
+extraParams.putString("accountId", "MY_ACCOUNT_ID");
+bp.purchase(YOUR_ACTIVITY, "YOUR PRODUCT ID FROM GOOGLE PLAY CONSOLE HERE", null /*or developer payload*/, extraParams);
+bp.subscribe(YOUR_ACTIVITY, "YOUR SUBSCRIPTION ID FROM GOOGLE PLAY CONSOLE HERE", null /*or developer payload*/, extraParams);
+```
+
+Use these methods if you want to pass extra parameters, [as documented here](https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams), you can provide a Bundle object.
+
+_Please note that this feature is only available if the target device is support the version 7 of the In App billing API._
+
 * **That's it! A super small and fast in-app library ever!**
 
 * **And don't forget**

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -303,22 +303,62 @@ public class BillingProcessor extends BillingBase
 
 	public boolean purchase(Activity activity, String productId)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, null);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, null, null);
 	}
 
 	public boolean subscribe(Activity activity, String productId)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, null);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, null, null);
 	}
 
 	public boolean purchase(Activity activity, String productId, String developerPayload)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload, null);
 	}
 
 	public boolean subscribe(Activity activity, String productId, String developerPayload)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, null);
+	}
+
+	/***
+	 * Purchase a product
+	 *
+	 * @param activity the activity calling this method
+	 * @param productId the product id to purchase
+	 * @param extraParamsBundle A bundle object containing extra parameters to pass to
+	 *                          getBuyIntentExtraParams()
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty
+	 * or if an exception occurs. Will return {@code true} otherwise.
+	 */
+	public boolean purchase(Activity activity, String productId, Bundle extraParamsBundle)
+	{
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, null, extraParamsBundle);
+	}
+
+	/**
+	 * Subscribe to a product
+	 *
+	 * @param activity the activity calling this method
+	 * @param productId the product id to purchase
+	 * @param extraParamsBundle A bundle object containing extra parameters to pass to getBuyIntentExtraParams()
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty or if an exception occurs. Will return {@code true} otherwise.
+	 */
+	public boolean subscribe(Activity activity, String productId, Bundle extraParamsBundle)
+	{
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, null, extraParamsBundle);
+	}
+
+	public boolean purchase(Activity activity, String productId, String developerPayload, Bundle extraParamsBundle)
+	{
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload, extraParamsBundle);
+	}
+
+	public boolean subscribe(Activity activity, String productId, String developerPayload, Bundle extraParamsBundle)
+	{
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, extraParamsBundle);
 	}
 
 	public boolean isOneTimePurchaseSupported()
@@ -375,7 +415,7 @@ public class BillingProcessor extends BillingBase
 	 */
 	public boolean updateSubscription(Activity activity, String oldProductId, String productId)
 	{
-		return updateSubscription(activity, oldProductId, productId, null);
+		return updateSubscription(activity, oldProductId, productId, null, null);
 	}
 
 	/**
@@ -390,13 +430,32 @@ public class BillingProcessor extends BillingBase
 	 */
 	public boolean updateSubscription(Activity activity, String oldProductId, String productId, String developerPayload)
 	{
+		return updateSubscription(activity, oldProductId, productId, developerPayload, null);
+	}
+
+	/**
+	 * Change subscription i.e. upgrade or downgrade
+	 *
+	 * @param activity     the activity calling this method
+	 * @param oldProductId passing null or empty string will act the same as {@link #subscribe(Activity, String)}
+	 * @param productId    the new subscription id
+	 * @param developerPayload the developer payload
+	 * @param extraParamsBundle A bundle object containing extra parameters (See developer.android.com documentation)
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @return {@code false} if {@code oldProductId} is not {@code null} AND change subscription
+	 * is not supported.
+	 */
+	public boolean updateSubscription(Activity activity, String oldProductId, String productId,
+									  String developerPayload, Bundle extraParamsBundle)
+	{
 		List<String> oldProductIds = null;
 		if (!TextUtils.isEmpty(oldProductId))
 		{
 			oldProductIds = Collections.singletonList(oldProductId);
 		}
-		return updateSubscription(activity, oldProductIds, productId, developerPayload);
+		return updateSubscription(activity, oldProductIds, productId, developerPayload, extraParamsBundle);
 	}
+
 
 	/**
 	 * Change subscription i.e. upgrade or downgrade
@@ -410,8 +469,34 @@ public class BillingProcessor extends BillingBase
 	public boolean updateSubscription(Activity activity, List<String> oldProductIds,
 									  String productId)
 	{
-		return updateSubscription(activity, oldProductIds, productId, null);
+		return updateSubscription(activity, oldProductIds, productId, null, null);
 	}
+
+
+	/**
+	 * Change subscription i.e. upgrade or downgrade
+	 *
+	 * @param activity      the activity calling this method
+	 * @param oldProductIds passing null will act the same as {@link #subscribe(Activity, String)}
+	 * @param productId     the new subscription id
+	 * @param developerPayload the developer payload
+	 * @param extraParamsBundle A bundle object containing extra parameters (See developer.android.com documentation)
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @return {@code false} if {@code oldProductIds} is not {@code null} AND change subscription
+	 * is not supported.
+	 */
+	public boolean updateSubscription(Activity activity, List<String> oldProductIds,
+									  String productId, String developerPayload,
+									  Bundle extraParamsBundle)
+	{
+		if (oldProductIds != null && !isSubscriptionUpdateSupported())
+		{
+			return false;
+		}
+		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION,
+				developerPayload, extraParamsBundle);
+	}
+
 
 	/**
 	 * Change subscription i.e. upgrade or downgrade
@@ -430,17 +515,17 @@ public class BillingProcessor extends BillingBase
 		{
 			return false;
 		}
-		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload);
+		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, null);
 	}
 
 	private boolean purchase(Activity activity, String productId, String purchaseType,
-							 String developerPayload)
+							 String developerPayload, Bundle extraParamsBundle)
 	{
-		return purchase(activity, null, productId, purchaseType, developerPayload);
+		return purchase(activity, null, productId, purchaseType, developerPayload, extraParamsBundle);
 	}
 
 	private boolean purchase(Activity activity, List<String> oldProductIds, String productId,
-							 String purchaseType, String developerPayload)
+							 String purchaseType, String developerPayload, Bundle extraParamsBundle)
 	{
 		if (!isInitialized() || TextUtils.isEmpty(productId) || TextUtils.isEmpty(purchaseType))
 		{
@@ -461,21 +546,28 @@ public class BillingProcessor extends BillingBase
 			Bundle bundle;
 			if (oldProductIds != null && purchaseType.equals(Constants.PRODUCT_TYPE_SUBSCRIPTION))
 			{
-				bundle =
-						billingService.getBuyIntentToReplaceSkus(Constants.GOOGLE_API_SUBSCRIPTION_CHANGE_VERSION,
-																 contextPackageName,
-																 oldProductIds,
-																 productId,
-																 purchaseType,
-																 purchasePayload);
+				int apiVersion = Constants.GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION;
+
+				if (extraParamsBundle == null)
+				{
+					extraParamsBundle = new Bundle();
+				}
+
+				if (!extraParamsBundle.containsKey(Constants.EXTRA_PARAMS_KEY_SKU_TO_REPLACE))
+				{
+					extraParamsBundle.putStringArrayList(Constants.EXTRA_PARAMS_KEY_SKU_TO_REPLACE, new ArrayList<String>(oldProductIds));
+				}
+
+				if( extraParamsBundle.containsKey(Constants.EXTRA_PARAMS_KEY_VR))
+				{
+					apiVersion = Constants.GOOGLE_API_VR_SUPPORTED_VERSION;
+				}
+
+				bundle = billingService.getBuyIntentExtraParams(apiVersion, contextPackageName, productId, purchaseType,purchasePayload, extraParamsBundle);
 			}
 			else
 			{
-				bundle = billingService.getBuyIntent(Constants.GOOGLE_API_VERSION,
-													 contextPackageName,
-													 productId,
-													 purchaseType,
-													 purchasePayload);
+				bundle = billingService.getBuyIntentExtraParams(Constants.GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION, contextPackageName, productId, purchaseType, purchasePayload, extraParamsBundle);
 			}
 
 			if (bundle != null)

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -328,7 +328,8 @@ public class BillingProcessor extends BillingBase
 	 * @param productId the product id to purchase
 	 * @param extraParamsBundle A bundle object containing extra parameters to pass to
 	 *                          getBuyIntentExtraParams()
-	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
+	 * params documentation on developer.android.com</a>
 	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty
 	 * or if an exception occurs. Will return {@code true} otherwise.
 	 */
@@ -343,8 +344,10 @@ public class BillingProcessor extends BillingBase
 	 * @param activity the activity calling this method
 	 * @param productId the product id to purchase
 	 * @param extraParamsBundle A bundle object containing extra parameters to pass to getBuyIntentExtraParams()
-	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
-	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty or if an exception occurs. Will return {@code true} otherwise.
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
+	 * params documentation on developer.android.com</a>
+	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty or if an exception occurs.
+	 * Will return {@code true} otherwise.
 	 */
 	public boolean subscribe(Activity activity, String productId, Bundle extraParamsBundle)
 	{
@@ -441,7 +444,8 @@ public class BillingProcessor extends BillingBase
 	 * @param productId    the new subscription id
 	 * @param developerPayload the developer payload
 	 * @param extraParamsBundle A bundle object containing extra parameters (See developer.android.com documentation)
-	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
+     * params documentation on developer.android.com</a>
 	 * @return {@code false} if {@code oldProductId} is not {@code null} AND change subscription
 	 * is not supported.
 	 */
@@ -455,7 +459,6 @@ public class BillingProcessor extends BillingBase
 		}
 		return updateSubscription(activity, oldProductIds, productId, developerPayload, extraParamsBundle);
 	}
-
 
 	/**
 	 * Change subscription i.e. upgrade or downgrade
@@ -472,7 +475,6 @@ public class BillingProcessor extends BillingBase
 		return updateSubscription(activity, oldProductIds, productId, null, null);
 	}
 
-
 	/**
 	 * Change subscription i.e. upgrade or downgrade
 	 *
@@ -481,7 +483,8 @@ public class BillingProcessor extends BillingBase
 	 * @param productId     the new subscription id
 	 * @param developerPayload the developer payload
 	 * @param extraParamsBundle A bundle object containing extra parameters (See developer.android.com documentation)
-	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra params documentation on developer.android.com</a>
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
+	 * params documentation on developer.android.com</a>
 	 * @return {@code false} if {@code oldProductIds} is not {@code null} AND change subscription
 	 * is not supported.
 	 */
@@ -555,7 +558,8 @@ public class BillingProcessor extends BillingBase
 
 				if (!extraParamsBundle.containsKey(Constants.EXTRA_PARAMS_KEY_SKU_TO_REPLACE))
 				{
-					extraParamsBundle.putStringArrayList(Constants.EXTRA_PARAMS_KEY_SKU_TO_REPLACE, new ArrayList<String>(oldProductIds));
+					extraParamsBundle.putStringArrayList(Constants.EXTRA_PARAMS_KEY_SKU_TO_REPLACE,
+							new ArrayList<String>(oldProductIds));
 				}
 
 				if( extraParamsBundle.containsKey(Constants.EXTRA_PARAMS_KEY_VR))
@@ -563,11 +567,13 @@ public class BillingProcessor extends BillingBase
 					apiVersion = Constants.GOOGLE_API_VR_SUPPORTED_VERSION;
 				}
 
-				bundle = billingService.getBuyIntentExtraParams(apiVersion, contextPackageName, productId, purchaseType,purchasePayload, extraParamsBundle);
+				bundle = billingService.getBuyIntentExtraParams(apiVersion, contextPackageName, productId,
+						purchaseType, purchasePayload, extraParamsBundle);
 			}
 			else
 			{
-				bundle = billingService.getBuyIntentExtraParams(Constants.GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION, contextPackageName, productId, purchaseType, purchasePayload, extraParamsBundle);
+				bundle = billingService.getBuyIntentExtraParams(Constants.GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION,
+						contextPackageName, productId, purchaseType, purchasePayload, extraParamsBundle);
 			}
 
 			if (bundle != null)

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -413,6 +413,12 @@ public class BillingProcessor extends BillingBase
 		return isSubsUpdateSupported;
 	}
 
+	/**
+	 * Check API v7 support for subscriptions
+	 * @param extraParams
+	 * @return {@code true} if the current API supports calling getBuyIntentExtraParams() for
+	 * subscriptions, {@code false} otherwise.
+	 */
 	public boolean isSubscriptionWithExtraParamsSupported(Bundle extraParams)
 	{
 		if(isSubscriptionExtraParamsSupported)
@@ -435,6 +441,12 @@ public class BillingProcessor extends BillingBase
 		return isSubscriptionExtraParamsSupported;
 	}
 
+	/**
+	 * Check API v7 support for one-time purchases
+	 * @param extraParams
+	 * @return {@code true} if the current API supports calling getBuyIntentExtraParams() for
+	 * one-time purchases, {@code false} otherwise.
+	 */
 	public boolean isOneTimePurchaseWithExtraParamsSupported(Bundle extraParams)
 	{
 		if(isOneTimePurchaseExtraParamsSupported)
@@ -539,7 +551,7 @@ public class BillingProcessor extends BillingBase
 	 * is not supported.
 	 */
 	public boolean updateSubscription(Activity activity, List<String> oldProductIds,
-													 String productId, String developerPayload, Bundle extraParams)
+									  String productId, String developerPayload, Bundle extraParams)
 	{
 		if (oldProductIds != null && !isSubscriptionUpdateSupported())
 		{
@@ -589,7 +601,7 @@ public class BillingProcessor extends BillingBase
 			Bundle bundle;
 			if (oldProductIds != null && purchaseType.equals(Constants.PRODUCT_TYPE_SUBSCRIPTION))
 			{
-				if(extraParamsBundle == null) // API v3
+				if(extraParamsBundle == null) // API v5
 				{
 					bundle = billingService.getBuyIntentToReplaceSkus(Constants.GOOGLE_API_SUBSCRIPTION_CHANGE_VERSION,
 							contextPackageName,
@@ -617,7 +629,7 @@ public class BillingProcessor extends BillingBase
 			}
 			else
 			{
-				if( extraParamsBundle == null) // API v3
+				if(extraParamsBundle == null) // API v3
 				{
 					bundle = billingService.getBuyIntent(Constants.GOOGLE_API_VERSION,
 							contextPackageName,

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -303,22 +303,22 @@ public class BillingProcessor extends BillingBase
 
 	public boolean purchase(Activity activity, String productId)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, null, null);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, null);
 	}
 
 	public boolean subscribe(Activity activity, String productId)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, null, null);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, null);
 	}
 
 	public boolean purchase(Activity activity, String productId, String developerPayload)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload, null);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload);
 	}
 
 	public boolean subscribe(Activity activity, String productId, String developerPayload)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, null);
+		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload);
 	}
 
 	/***
@@ -333,9 +333,9 @@ public class BillingProcessor extends BillingBase
 	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty
 	 * or if an exception occurs. Will return {@code true} otherwise.
 	 */
-	public boolean purchase(Activity activity, String productId, Bundle extraParamsBundle)
+	public boolean purchaseWithExtraParams(Activity activity, String productId, String developerPayload, Bundle extraParams)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, null, extraParamsBundle);
+		return purchase(activity, null, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload, extraParams);
 	}
 
 	/**
@@ -349,19 +349,9 @@ public class BillingProcessor extends BillingBase
 	 * @return {@code false} if the billing system is not initialized, {@code productId} is empty or if an exception occurs.
 	 * Will return {@code true} otherwise.
 	 */
-	public boolean subscribe(Activity activity, String productId, Bundle extraParamsBundle)
+	public boolean subscribeWithExtraParams(Activity activity, String productId, String developerPayload, Bundle extraParams)
 	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, null, extraParamsBundle);
-	}
-
-	public boolean purchase(Activity activity, String productId, String developerPayload, Bundle extraParamsBundle)
-	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_MANAGED, developerPayload, extraParamsBundle);
-	}
-
-	public boolean subscribe(Activity activity, String productId, String developerPayload, Bundle extraParamsBundle)
-	{
-		return purchase(activity, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, extraParamsBundle);
+		return purchase(activity, null, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, extraParams);
 	}
 
 	public boolean isOneTimePurchaseSupported()
@@ -418,7 +408,7 @@ public class BillingProcessor extends BillingBase
 	 */
 	public boolean updateSubscription(Activity activity, String oldProductId, String productId)
 	{
-		return updateSubscription(activity, oldProductId, productId, null, null);
+		return updateSubscription(activity, oldProductId, productId, null);
 	}
 
 	/**
@@ -433,31 +423,12 @@ public class BillingProcessor extends BillingBase
 	 */
 	public boolean updateSubscription(Activity activity, String oldProductId, String productId, String developerPayload)
 	{
-		return updateSubscription(activity, oldProductId, productId, developerPayload, null);
-	}
-
-	/**
-	 * Change subscription i.e. upgrade or downgrade
-	 *
-	 * @param activity     the activity calling this method
-	 * @param oldProductId passing null or empty string will act the same as {@link #subscribe(Activity, String)}
-	 * @param productId    the new subscription id
-	 * @param developerPayload the developer payload
-	 * @param extraParamsBundle A bundle object containing extra parameters (See developer.android.com documentation)
-	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
-     * params documentation on developer.android.com</a>
-	 * @return {@code false} if {@code oldProductId} is not {@code null} AND change subscription
-	 * is not supported.
-	 */
-	public boolean updateSubscription(Activity activity, String oldProductId, String productId,
-									  String developerPayload, Bundle extraParamsBundle)
-	{
 		List<String> oldProductIds = null;
 		if (!TextUtils.isEmpty(oldProductId))
 		{
 			oldProductIds = Collections.singletonList(oldProductId);
 		}
-		return updateSubscription(activity, oldProductIds, productId, developerPayload, extraParamsBundle);
+		return updateSubscription(activity, oldProductIds, productId, developerPayload);
 	}
 
 	/**
@@ -472,34 +443,9 @@ public class BillingProcessor extends BillingBase
 	public boolean updateSubscription(Activity activity, List<String> oldProductIds,
 									  String productId)
 	{
-		return updateSubscription(activity, oldProductIds, productId, null, null);
+		return updateSubscription(activity, oldProductIds, productId, null);
 	}
 
-	/**
-	 * Change subscription i.e. upgrade or downgrade
-	 *
-	 * @param activity      the activity calling this method
-	 * @param oldProductIds passing null will act the same as {@link #subscribe(Activity, String)}
-	 * @param productId     the new subscription id
-	 * @param developerPayload the developer payload
-	 * @param extraParamsBundle A bundle object containing extra parameters (See developer.android.com documentation)
-	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
-	 * params documentation on developer.android.com</a>
-	 * @return {@code false} if {@code oldProductIds} is not {@code null} AND change subscription
-	 * is not supported.
-	 */
-	public boolean updateSubscription(Activity activity, List<String> oldProductIds,
-									  String productId, String developerPayload,
-									  Bundle extraParamsBundle)
-	{
-		if (oldProductIds != null && !isSubscriptionUpdateSupported())
-		{
-			return false;
-		}
-		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION,
-				developerPayload, extraParamsBundle);
-	}
-	
 	/**
 	 * Change subscription i.e. upgrade or downgrade
 	 *
@@ -517,13 +463,39 @@ public class BillingProcessor extends BillingBase
 		{
 			return false;
 		}
-		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, null);
+		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload);
+	}
+
+	/**
+	 *
+	 * @param activity      the activity calling this method
+	 * @param oldProductIds passing null will act the same as {@link #subscribe(Activity, String)}
+	 * @param productId     the new subscription id
+	 * @param developerPayload the developer payload
+	 * @param extraParams  A bundle object containing extra parameters to pass to getBuyIntentExtraParams()
+	 * @see <a href="https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams">extra
+	 * params documentation on developer.android.com</a>
+	 * @return {@code false} if {@code oldProductIds} is not {@code null} AND change subscription
+	 * is not supported.
+	 */
+	public boolean updateSubscriptionWithExtraParams(Activity activity, List<String> oldProductIds,
+													 String productId, String developerPayload, Bundle extraParams){
+		if (oldProductIds != null && !isSubscriptionUpdateSupported())
+		{
+			return false;
+		}
+		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION, developerPayload, extraParams);
 	}
 
 	private boolean purchase(Activity activity, String productId, String purchaseType,
-							 String developerPayload, Bundle extraParamsBundle)
+							 String developerPayload)
 	{
-		return purchase(activity, null, productId, purchaseType, developerPayload, extraParamsBundle);
+		return purchase(activity, null, productId, purchaseType, developerPayload);
+	}
+
+	private boolean purchase(Activity activity, List<String> oldProductIds, String productId,
+							 String purchaseType, String developerPayload){
+		return purchase(activity, oldProductIds, productId, purchaseType, developerPayload, null);
 	}
 
 	private boolean purchase(Activity activity, List<String> oldProductIds, String productId,
@@ -561,7 +533,7 @@ public class BillingProcessor extends BillingBase
 							new ArrayList<String>(oldProductIds));
 				}
 
-				if( extraParamsBundle.containsKey(Constants.EXTRA_PARAMS_KEY_VR))
+				if(extraParamsBundle.containsKey(Constants.EXTRA_PARAMS_KEY_VR))
 				{
 					apiVersion = Constants.GOOGLE_API_VR_SUPPORTED_VERSION;
 				}

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -499,8 +499,7 @@ public class BillingProcessor extends BillingBase
 		return purchase(activity, oldProductIds, productId, Constants.PRODUCT_TYPE_SUBSCRIPTION,
 				developerPayload, extraParamsBundle);
 	}
-
-
+	
 	/**
 	 * Change subscription i.e. upgrade or downgrade
 	 *

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -479,7 +479,8 @@ public class BillingProcessor extends BillingBase
 	 * is not supported.
 	 */
 	public boolean updateSubscriptionWithExtraParams(Activity activity, List<String> oldProductIds,
-													 String productId, String developerPayload, Bundle extraParams){
+													 String productId, String developerPayload, Bundle extraParams)
+	{
 		if (oldProductIds != null && !isSubscriptionUpdateSupported())
 		{
 			return false;
@@ -494,7 +495,8 @@ public class BillingProcessor extends BillingBase
 	}
 
 	private boolean purchase(Activity activity, List<String> oldProductIds, String productId,
-							 String purchaseType, String developerPayload){
+							 String purchaseType, String developerPayload)
+	{
 		return purchase(activity, oldProductIds, productId, purchaseType, developerPayload, null);
 	}
 

--- a/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
@@ -19,7 +19,6 @@ public class Constants
 {
 	public static final int GOOGLE_API_VERSION = 3;
 	public static final int GOOGLE_API_SUBSCRIPTION_CHANGE_VERSION = 5;
-	public static final int GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION = 6;
 	public static final int GOOGLE_API_VR_SUPPORTED_VERSION = 7;
 
 	public static final String PRODUCT_TYPE_MANAGED = "inapp";

--- a/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
@@ -22,7 +22,6 @@ public class Constants
 	public static final int GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION = 6;
 	public static final int GOOGLE_API_VR_SUPPORTED_VERSION = 7;
 
-
 	public static final String PRODUCT_TYPE_MANAGED = "inapp";
 	public static final String PRODUCT_TYPE_SUBSCRIPTION = "subs";
 
@@ -92,6 +91,4 @@ public class Constants
 
 	public static final String EXTRA_PARAMS_KEY_VR = "vr";
 	public static final String EXTRA_PARAMS_KEY_SKU_TO_REPLACE = "skusToReplace";
-
-
 }

--- a/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
@@ -19,6 +19,9 @@ public class Constants
 {
 	public static final int GOOGLE_API_VERSION = 3;
 	public static final int GOOGLE_API_SUBSCRIPTION_CHANGE_VERSION = 5;
+	public static final int GOOGLE_API_EXTRA_PARAMS_SUPPORTED_VERSION = 6;
+	public static final int GOOGLE_API_VR_SUPPORTED_VERSION = 7;
+
 
 	public static final String PRODUCT_TYPE_MANAGED = "inapp";
 	public static final String PRODUCT_TYPE_SUBSCRIPTION = "subs";
@@ -86,4 +89,9 @@ public class Constants
 	public static final int BILLING_ERROR_CONSUME_FAILED = 111;
 	public static final int BILLING_ERROR_SKUDETAILS_FAILED = 112;
 	public static final int BILLING_ERROR_BIND_PLAY_STORE_FAILED = 113;
+
+	public static final String EXTRA_PARAMS_KEY_VR = "vr";
+	public static final String EXTRA_PARAMS_KEY_SKU_TO_REPLACE = "skusToReplace";
+
+
 }


### PR DESCRIPTION
This PR addresses issue #241, adding support for getBuyIntentExtraParams() as this is the recommended method by Google.
https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntent

> The method is a variant of the getBuyIntent() method, and takes an additional extraParams parameter.

More info here: https://developer.android.com/google/play/billing/billing_reference.html#getBuyIntentExtraParams