### PR TITLE
Enhancement/load owned purchases from google

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -63,10 +63,20 @@
           </extensions>
         </Objective-C-extensions>
         <XML>
-          <option name="XML_KEEP_LINE_BREAKS" value="false" />
-          <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-          <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
+        <codeStyleSettings language="JAVA">
+          <option name="BRACE_STYLE" value="2" />
+          <option name="CLASS_BRACE_STYLE" value="2" />
+          <option name="METHOD_BRACE_STYLE" value="2" />
+          <option name="ELSE_ON_NEW_LINE" value="true" />
+          <option name="CATCH_ON_NEW_LINE" value="true" />
+          <option name="FINALLY_ON_NEW_LINE" value="true" />
+          <option name="IF_BRACE_FORCE" value="3" />
+          <option name="DOWHILE_BRACE_FORCE" value="3" />
+          <option name="WHILE_BRACE_FORCE" value="3" />
+          <option name="FOR_BRACE_FORCE" value="3" />
+        </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
           <indentOptions>
@@ -226,6 +236,6 @@
         </codeStyleSettings>
       </value>
     </option>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default (2)" />
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </component>
 </project>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -31,6 +31,7 @@
           </value>
         </option>
         <option name="RIGHT_MARGIN" value="100" />
+        <option name="JD_P_AT_EMPTY_LINES" value="false" />
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />
         </AndroidXmlCodeStyleSettings>
@@ -76,6 +77,9 @@
           <option name="DOWHILE_BRACE_FORCE" value="3" />
           <option name="WHILE_BRACE_FORCE" value="3" />
           <option name="FOR_BRACE_FORCE" value="3" />
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
         </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />

--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ bp.consumePurchase("YOUR PRODUCT ID FROM GOOGLE PLAY CONSOLE HERE");
 bp.loadOwnedPurchasesFromGoogle();
 ```
 
+Note that this will fetch the purchases synchronously, and may block the thread.
+Avoid calling this on the UI thread if possible.
+
 ## Getting Listing Details of Your Products
 
 To query listing price and a description of your product / subscription listed in Google Play use these methods:

--- a/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
@@ -1,94 +1,105 @@
+/**
+ * Copyright 2014 AnjLab
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.anjlab.android.iab.v3;
 
 import android.os.AsyncTask;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
-
-/**
- * Created by Allan Wang on 2017-08-07.
- */
 
 public class AsyncBilling
 {
 
-    public static void loadOwnedPurchasesFromGoogleAsync(BillingProcessor billingProcessor, IAsyncResponse<Boolean> response)
-    {
-        doAsync(billingProcessor, new IAsyncTask<Boolean>()
-        {
-            @Override
-            public Boolean doInBackground(@NonNull BillingProcessor billingProcessor)
-            {
-                return billingProcessor.loadOwnedPurchasesFromGoogle();
-            }
-        }, response);
-    }
+	static <T> void doAsync(BillingProcessor billingProcessor, IAsyncTask<T> backgroundTask, IAsyncResponse<T> uiResponse)
+	{
+		new AsyncBillingTask<>(billingProcessor, backgroundTask, uiResponse).execute();
+	}
 
-    public interface IAsyncTask<T>
-    {
-        T doInBackground(@NonNull BillingProcessor billingProcessor);
-    }
+	interface IAsyncTask<T>
+	{
+		/**
+		 * Task to execute with the given {@link BillingProcessor}
+		 *
+		 * @param bp the nonnull and initialized billing processor
+		 * @return result
+		 */
+		T doInBackground(@NonNull BillingProcessor bp);
+	}
 
-    public interface IAsyncResponse<T>
-    {
-        void onResponse(T response);
+	public interface IAsyncResponse<T>
+	{
+		/**
+		 * Guaranteed callback from the async task
+		 *
+		 * @param response  the response from {@link IAsyncTask}, or {@code null} is invalid
+		 * @param valid {@code true} if billing processor reference is still valid and initialized
+		 */
+		void onResponse(@Nullable T response, boolean valid);
+	}
 
-        void onCancelled();
-    }
+	/**
+	 * Generic async task, binding a {@link BillingProcessor}
+	 *
+	 * @param <T> response type
+	 */
+	private static class AsyncBillingTask<T> extends AsyncTask<Void, Void, T>
+	{
 
-    public static <T> void doAsync(BillingProcessor billingProcessor, IAsyncTask<T> backgroundTask, IAsyncResponse<T> uiResponse)
-    {
-        new AsyncBillingTask<>(billingProcessor, backgroundTask, uiResponse).execute();
-    }
+		private final WeakReference<BillingProcessor> bpRef;
+		private final IAsyncTask<T> bgTask;
+		private final IAsyncResponse<T> uiResponse;
 
-    private static class AsyncBillingTask<T> extends AsyncTask<Void, Void, T>
-    {
+		private AsyncBillingTask(BillingProcessor bp, IAsyncTask<T> bgTask, IAsyncResponse<T> uiResponse)
+		{
+			this.bpRef = new WeakReference<>(bp);
+			this.bgTask = bgTask;
+			this.uiResponse = uiResponse;
+		}
 
-        private final WeakReference<BillingProcessor> bpRef;
-        private final IAsyncTask<T> bgTask;
-        private final IAsyncResponse<T> uiResponse;
+		@Override
+		protected T doInBackground(Void... voids)
+		{
+			BillingProcessor bp = bpRef.get();
+			if (bp == null || !bp.isInitialized())
+			{
+				return null;
+			}
+			return bgTask.doInBackground(bp);
+		}
 
-        private AsyncBillingTask(BillingProcessor bp, IAsyncTask<T> bgTask, IAsyncResponse<T> uiResponse)
-        {
-            this.bpRef = new WeakReference<>(bp);
-            this.bgTask = bgTask;
-            this.uiResponse = uiResponse;
-        }
+		@Override
+		protected void onCancelled()
+		{
+			uiResponse.onResponse(null, false);
+		}
 
-        @Override
-        protected T doInBackground(Void... voids)
-        {
-            BillingProcessor bp = bpRef.get();
-            if (bp == null || !bp.isInitialized())
-            {
-                return null;
-            }
-            return bgTask.doInBackground(bp);
-        }
-
-        @Override
-        protected void onCancelled()
-        {
-            uiResponse.onCancelled();
-        }
-
-        @Override
-        protected void onPostExecute(T t)
-        {
-            //todo check if we should verify that the billing processor is still valid
-            //even though the response may not depend on the billing processor, it may indicate that
-            //the bounded activity is finished
-            BillingProcessor bp = bpRef.get();
-            if (t == null && (bp == null || !bp.isInitialized()))
-            {
-                //we skipped the task as the processor isn't ready
-                uiResponse.onCancelled();
-            }
-            else
-            {
-                uiResponse.onResponse(t);
-            }
-        }
-    }
+		@Override
+		protected void onPostExecute(T t)
+		{
+			BillingProcessor bp = bpRef.get();
+			if (t == null && (bp == null || !bp.isInitialized()))
+			{
+				onCancelled(); //we skipped the task as the processor isn't ready
+			}
+			else
+			{
+				uiResponse.onResponse(t, true);
+			}
+		}
+	}
 
 }

--- a/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
@@ -9,67 +9,83 @@ import java.lang.ref.WeakReference;
  * Created by Allan Wang on 2017-08-07.
  */
 
-public class AsyncBilling {
+public class AsyncBilling
+{
 
-    public static void loadOwnedPurchasesFromGoogleAsync(BillingProcessor billingProcessor, IAsyncResponse<Boolean> response) {
-        doAsync(billingProcessor, new IAsyncTask<Boolean>() {
+    public static void loadOwnedPurchasesFromGoogleAsync(BillingProcessor billingProcessor, IAsyncResponse<Boolean> response)
+    {
+        doAsync(billingProcessor, new IAsyncTask<Boolean>()
+        {
             @Override
-            public Boolean doInBackground(@NonNull BillingProcessor billingProcessor) {
+            public Boolean doInBackground(@NonNull BillingProcessor billingProcessor)
+            {
                 return billingProcessor.loadOwnedPurchasesFromGoogle();
             }
         }, response);
     }
 
-    public interface IAsyncTask<T> {
+    public interface IAsyncTask<T>
+    {
         T doInBackground(@NonNull BillingProcessor billingProcessor);
     }
 
-    public interface IAsyncResponse<T> {
+    public interface IAsyncResponse<T>
+    {
         void onResponse(T response);
 
         void onCancelled();
     }
 
-    public static <T> void doAsync(BillingProcessor billingProcessor, IAsyncTask<T> backgroundTask, IAsyncResponse<T> uiResponse) {
+    public static <T> void doAsync(BillingProcessor billingProcessor, IAsyncTask<T> backgroundTask, IAsyncResponse<T> uiResponse)
+    {
         new AsyncBillingTask<>(billingProcessor, backgroundTask, uiResponse).execute();
     }
 
-    private static class AsyncBillingTask<T> extends AsyncTask<Void, Void, T> {
+    private static class AsyncBillingTask<T> extends AsyncTask<Void, Void, T>
+    {
 
         private final WeakReference<BillingProcessor> bpRef;
         private final IAsyncTask<T> bgTask;
         private final IAsyncResponse<T> uiResponse;
 
-        private AsyncBillingTask(BillingProcessor bp, IAsyncTask<T> bgTask, IAsyncResponse<T> uiResponse) {
+        private AsyncBillingTask(BillingProcessor bp, IAsyncTask<T> bgTask, IAsyncResponse<T> uiResponse)
+        {
             this.bpRef = new WeakReference<>(bp);
             this.bgTask = bgTask;
             this.uiResponse = uiResponse;
         }
 
         @Override
-        protected T doInBackground(Void... voids) {
+        protected T doInBackground(Void... voids)
+        {
             BillingProcessor bp = bpRef.get();
-            if (bp == null || !bp.isInitialized()) {
+            if (bp == null || !bp.isInitialized())
+            {
                 return null;
             }
             return bgTask.doInBackground(bp);
         }
 
         @Override
-        protected void onCancelled() {
+        protected void onCancelled()
+        {
             uiResponse.onCancelled();
         }
 
         @Override
-        protected void onPostExecute(T t) {
+        protected void onPostExecute(T t)
+        {
             //todo check if we should verify that the billing processor is still valid
             //even though the response may not depend on the billing processor, it may indicate that
             //the bounded activity is finished
             BillingProcessor bp = bpRef.get();
-            if (t == null && (bp == null || !bp.isInitialized())) {
+            if (t == null && (bp == null || !bp.isInitialized()))
+            {
                 //we skipped the task as the processor isn't ready
                 uiResponse.onCancelled();
-            } else {
+            }
+            else
+            {
                 uiResponse.onResponse(t);
             }
         }

--- a/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
@@ -11,7 +11,7 @@ import java.lang.ref.WeakReference;
 
 public class AsyncBilling {
 
-    public static void loadPurchasesFromGoogleAsync(BillingProcessor billingProcessor, IAsyncResponse<Boolean> response) {
+    public static void loadOwnedPurchasesFromGoogleAsync(BillingProcessor billingProcessor, IAsyncResponse<Boolean> response) {
         doAsync(billingProcessor, new IAsyncTask<Boolean>() {
             @Override
             public Boolean doInBackground(@NonNull BillingProcessor billingProcessor) {
@@ -49,7 +49,9 @@ public class AsyncBilling {
         @Override
         protected T doInBackground(Void... voids) {
             BillingProcessor bp = bpRef.get();
-            if (bp == null || !bp.isInitialized()) return null;
+            if (bp == null || !bp.isInitialized()) {
+                return null;
+            }
             return bgTask.doInBackground(bp);
         }
 
@@ -63,7 +65,13 @@ public class AsyncBilling {
             //todo check if we should verify that the billing processor is still valid
             //even though the response may not depend on the billing processor, it may indicate that
             //the bounded activity is finished
-            uiResponse.onResponse(t);
+            BillingProcessor bp = bpRef.get();
+            if (t == null && (bp == null || !bp.isInitialized())) {
+                //we skipped the task as the processor isn't ready
+                uiResponse.onCancelled();
+            } else {
+                uiResponse.onResponse(t);
+            }
         }
     }
 

--- a/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/AsyncBilling.java
@@ -1,0 +1,70 @@
+package com.anjlab.android.iab.v3;
+
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Created by Allan Wang on 2017-08-07.
+ */
+
+public class AsyncBilling {
+
+    public static void loadPurchasesFromGoogleAsync(BillingProcessor billingProcessor, IAsyncResponse<Boolean> response) {
+        doAsync(billingProcessor, new IAsyncTask<Boolean>() {
+            @Override
+            public Boolean doInBackground(@NonNull BillingProcessor billingProcessor) {
+                return billingProcessor.loadOwnedPurchasesFromGoogle();
+            }
+        }, response);
+    }
+
+    public interface IAsyncTask<T> {
+        T doInBackground(@NonNull BillingProcessor billingProcessor);
+    }
+
+    public interface IAsyncResponse<T> {
+        void onResponse(T response);
+
+        void onCancelled();
+    }
+
+    public static <T> void doAsync(BillingProcessor billingProcessor, IAsyncTask<T> backgroundTask, IAsyncResponse<T> uiResponse) {
+        new AsyncBillingTask<>(billingProcessor, backgroundTask, uiResponse).execute();
+    }
+
+    private static class AsyncBillingTask<T> extends AsyncTask<Void, Void, T> {
+
+        private final WeakReference<BillingProcessor> bpRef;
+        private final IAsyncTask<T> bgTask;
+        private final IAsyncResponse<T> uiResponse;
+
+        private AsyncBillingTask(BillingProcessor bp, IAsyncTask<T> bgTask, IAsyncResponse<T> uiResponse) {
+            this.bpRef = new WeakReference<>(bp);
+            this.bgTask = bgTask;
+            this.uiResponse = uiResponse;
+        }
+
+        @Override
+        protected T doInBackground(Void... voids) {
+            BillingProcessor bp = bpRef.get();
+            if (bp == null || !bp.isInitialized()) return null;
+            return bgTask.doInBackground(bp);
+        }
+
+        @Override
+        protected void onCancelled() {
+            uiResponse.onCancelled();
+        }
+
+        @Override
+        protected void onPostExecute(T t) {
+            //todo check if we should verify that the billing processor is still valid
+            //even though the response may not depend on the billing processor, it may indicate that
+            //the bounded activity is finished
+            uiResponse.onResponse(t);
+        }
+    }
+
+}

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -308,7 +308,7 @@ public class BillingProcessor extends BillingBase
 	}
 
 	/**
-	 * Attempt to fetch purchases from the server and update our cache if successful
+	 * Attempt to fetch purchases synchronously from the server and update our cache if successful
 	 *
 	 * @return {@code true} if all retrievals are successful, {@code false} otherwise
 	 */


### PR DESCRIPTION
**Not ready for merging**
- [x] Document `loadOwnedPurchasesFromGoogle` as synchronous
- [x] Add async counterpart

The async class is just a showcase of a potential workaround. If it is accepted, it will be added in the billing processor class and will not be static. It also holds a generic AsyncTask so it can also be used when loading the history to avoid two classes for small functions.

Address #296 