### PR TITLE
Add getSkuDetailsOrThrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ where arrayListOfProductIds is a `ArrayList<String>` containing either IDs for p
 
 As a result you will get a `List<SkuDetails>` which contains objects described above.
 
+If you want to handle connection errors (user doesn't have internet) use these methods:
+
+```java
+try {
+    bp.getPurchaseListingDetailsOrThrow(arrayListOfProductIds);
+} catch (Exception e) {
+    // Your code here
+}
+try {
+    bp.getPurchaseListingDetailsOrThrow(arrayListOfProductIds);
+} catch (Excepetion e) {
+    // Your code here
+}
+```
+
+
 ## Getting Purchase Transaction Details
 As a part or 1.0.9 changes, `TransactionDetails` object is passed to `onProductPurchased` method of a handler class.
 However, you can always retrieve it later calling these methods:

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ try {
     // Your code here
 }
 try {
-    bp.getPurchaseListingDetailsOrThrow(arrayListOfProductIds);
+    bp.getSubscriptionListingDetailsOrThrow(arrayListOfProductIds);
 } catch (Excepetion e) {
     // Your code here
 }

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingError.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingError.java
@@ -1,0 +1,22 @@
+package com.anjlab.android.iab.v3;
+
+public class BillingError extends Exception
+{
+    private int responseCode;
+
+    public BillingError(int responseCode)
+    {
+        this.responseCode = responseCode;
+    }
+
+    public int getResponseCode()
+    {
+        return responseCode;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "BillingError: Code " + Integer.toString(responseCode);
+    }
+}

--- a/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/Constants.java
@@ -93,6 +93,7 @@ public class Constants
 	public static final int BILLING_ERROR_CONSUME_FAILED = 111;
 	public static final int BILLING_ERROR_SKUDETAILS_FAILED = 112;
 	public static final int BILLING_ERROR_BIND_PLAY_STORE_FAILED = 113;
+	public static final int BILLING_ERROR_SERVICE_DISCONNECTED = 114;
 
 	public static final String EXTRA_PARAMS_KEY_VR = "vr";
 	public static final String EXTRA_PARAMS_KEY_SKU_TO_REPLACE = "skusToReplace";

--- a/sample/src/com/anjlab/android/iab/v3/sample2/MainActivity.java
+++ b/sample/src/com/anjlab/android/iab/v3/sample2/MainActivity.java
@@ -29,6 +29,8 @@ import com.anjlab.android.iab.v3.BillingProcessor;
 import com.anjlab.android.iab.v3.SkuDetails;
 import com.anjlab.android.iab.v3.TransactionDetails;
 
+import java.util.ArrayList;
+
 public class MainActivity extends Activity {
 	// SAMPLE APP CONSTANTS
 	private static final String ACTIVITY_NUMBER = "activity_num";
@@ -133,8 +135,13 @@ public class MainActivity extends Activity {
                     showToast("Successfully consumed");
                 break;
             case R.id.productDetailsButton:
-				SkuDetails sku = bp.getPurchaseListingDetails(PRODUCT_ID);
-                showToast(sku != null ? sku.toString() : "Failed to load SKU details");
+                ArrayList<String> products = new ArrayList<>();
+                products.add(PRODUCT_ID);
+                try {
+                    showToast(bp.getPurchaseListingDetailsOrThrow(products).get(0).toString());
+                } catch (Exception e) {
+                    showToast("Failed to load SKU details: " + e);
+                }
                 break;
             case R.id.subscribeButton:
                 bp.subscribe(this,SUBSCRIPTION_ID);


### PR DESCRIPTION
This variant of getSkuDetails raises exceptions when the request fails instead of using reportBillingError.

Without this, when calling getSkuDetails, a synchronous method, you have to be prepared to receive errors somewhere unrelated.