### PR TITLE
Issue #253 solution

### DIFF
--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -385,7 +385,8 @@ public class BillingProcessor extends BillingBase
 
 	public boolean isOneTimePurchaseSupported()
 	{
-		if(!isInitialized()){
+		if(!isInitialized())
+		{
 			Log.e(LOG_TAG, "Make sure BillingProcessor was initialized (by checking isInitialized()) before calling isOneTimePurchaseSupported()");
 			return false;
 		}

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -385,6 +385,10 @@ public class BillingProcessor extends BillingBase
 
 	public boolean isOneTimePurchaseSupported()
 	{
+		if(!isInitialized()){
+			Log.e(LOG_TAG, "Make sure BillingProcessor was initialized (by checking isInitialized()) before calling isOneTimePurchaseSupported()");
+			return false;
+		}
 		if (isOneTimePurchasesSupported)
 		{
 			return true;

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -387,7 +387,7 @@ public class BillingProcessor extends BillingBase
 	{
 		if(!isInitialized())
 		{
-			Log.e(LOG_TAG, "Make sure BillingProcessor was initialized (by checking isInitialized()) before calling isOneTimePurchaseSupported()");
+			Log.e(LOG_TAG, "Make sure BillingProcessor was initialized before calling isOneTimePurchaseSupported()");
 			return false;
 		}
 		if (isOneTimePurchasesSupported)


### PR DESCRIPTION
As mention in the issue #253 there is a crash if the isOneTimePurchaseSupported() method is called before the BillingProcessor was initialised. Hence I added a check to that method, which also logs an error which reminds about the check necessary.. 