### PR TITLE
Fix user canceled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ gen/
 !.idea/codeStyleSettings.xml
 build
 local.properties
-gradle.properties
+#gradle.properties
 .gradle
 *.iml
 .DS_Store

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+# Project-wide Gradle settings.
+
+android.useAndroidX=true
+android.enableJetifier=true
+
+

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -259,10 +259,20 @@ public class BillingProcessor extends BillingBase
 						handleItemAlreadyOwned(purchasePayload.split(":")[1]);
 						savePurchasePayload(null);
 					}
+
+					reportBillingError(responseCode, new Throwable(billingResult.getDebugMessage()));
+
 				}
-				else if (responseCode == BillingClient.BillingResponseCode.USER_CANCELED)
+				else if (responseCode == BillingClient.BillingResponseCode.USER_CANCELED
+						|| responseCode == BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE
+						|| responseCode == BillingClient.BillingResponseCode.BILLING_UNAVAILABLE
+						|| responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE
+						|| responseCode == BillingClient.BillingResponseCode.DEVELOPER_ERROR
+						|| responseCode == BillingClient.BillingResponseCode.ERROR
+						|| responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED
+						|| responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED)
 				{
-					reportBillingError(BillingClient.BillingResponseCode.USER_CANCELED, new Throwable(billingResult.getDebugMessage()));
+					reportBillingError(responseCode, new Throwable(billingResult.getDebugMessage()));
 				}
 			}
 		};

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -269,7 +269,6 @@ public class BillingProcessor extends BillingBase
 						|| responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE
 						|| responseCode == BillingClient.BillingResponseCode.DEVELOPER_ERROR
 						|| responseCode == BillingClient.BillingResponseCode.ERROR
-						|| responseCode == BillingClient.BillingResponseCode.ITEM_ALREADY_OWNED
 						|| responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED)
 				{
 					reportBillingError(responseCode, new Throwable(billingResult.getDebugMessage()));

--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -260,6 +260,10 @@ public class BillingProcessor extends BillingBase
 						savePurchasePayload(null);
 					}
 				}
+				else if (responseCode == BillingClient.BillingResponseCode.USER_CANCELED)
+				{
+					reportBillingError(BillingClient.BillingResponseCode.USER_CANCELED, new Throwable(billingResult.getDebugMessage()));
+				}
 			}
 		};
 

--- a/library/src/main/java/com/anjlab/android/iab/v3/PurchaseInfo.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/PurchaseInfo.java
@@ -29,10 +29,6 @@ import android.util.Log;
  * a purchase from the google play store on his own
  * server. An example implementation of how to verify
  * a purchase you can find here:
- * <pre>
- * See <a href="https://github.com/mgoldsborough/google-play-in-app-billing-verification/blob/
- * master/library/GooglePlay/InAppBilling/GooglePlayResponseValidator.php#L64"> here </a>
- * </pre>
  */
 public class PurchaseInfo implements Parcelable
 {

--- a/sample/src/com/anjlab/android/iab/v3/sample2/MainActivity.java
+++ b/sample/src/com/anjlab/android/iab/v3/sample2/MainActivity.java
@@ -39,7 +39,7 @@ public class MainActivity extends Activity {
     // PRODUCT & SUBSCRIPTION IDS
     private static final String PRODUCT_ID = "com.anjlab.test.iab.s2.p5";
     private static final String SUBSCRIPTION_ID = "com.anjlab.test.iab.subs1";
-    private static final String LICENSE_KEY = BuildConfig.licenceKey; // PUT YOUR MERCHANT KEY HERE;
+    private static final String LICENSE_KEY = "THE_KEY"; //BuildConfig.LICENSE_KEY; // PUT YOUR MERCHANT KEY HERE;
     // put your Google merchant id here (as stated in public profile of your Payments Merchant Center)
     // if filled library will provide protection against Freedom alike Play Market simulators
     private static final String MERCHANT_ID=null;


### PR DESCRIPTION
See: https://github.com/anjlab/android-inapp-billing-v3/issues/516

fixed various issues that caused the payment flow not call the listeners (e.g. when the user canceled or item was unavailable, etc.)

Some of the additionally triggered listeners like developer error might trigger double now, but better double then not receiving the errors. If any library author could double check that'd be awesome.