### PR TITLE
all errors are now propagated to the listeners again

### DIFF
--- a/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
+++ b/library/src/main/java/com/anjlab/android/iab/v3/BillingProcessor.java
@@ -259,6 +259,19 @@ public class BillingProcessor extends BillingBase
 						handleItemAlreadyOwned(purchasePayload.split(":")[1]);
 						savePurchasePayload(null);
 					}
+
+					reportBillingError(responseCode, new Throwable(billingResult.getDebugMessage()));
+
+				}
+				else if (responseCode == BillingClient.BillingResponseCode.USER_CANCELED
+						|| responseCode == BillingClient.BillingResponseCode.SERVICE_UNAVAILABLE
+						|| responseCode == BillingClient.BillingResponseCode.BILLING_UNAVAILABLE
+						|| responseCode == BillingClient.BillingResponseCode.ITEM_UNAVAILABLE
+						|| responseCode == BillingClient.BillingResponseCode.DEVELOPER_ERROR
+						|| responseCode == BillingClient.BillingResponseCode.ERROR
+						|| responseCode == BillingClient.BillingResponseCode.ITEM_NOT_OWNED)
+				{
+					reportBillingError(responseCode, new Throwable(billingResult.getDebugMessage()));
 				}
 			}
 		};


### PR DESCRIPTION
See: https://github.com/anjlab/android-inapp-billing-v3/issues/516
New try with cleaner history.

fixed various issues that caused the payment flow not call the listeners (e.g. when the user canceled or item was unavailable, etc.)

Some of the additionally triggered listeners like developer error might trigger double now, but better double then not receiving the errors. If any library author could double check that'd be awesome.

