### PR TITLE
Alternative sdk added in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ This is a simple, straight-forward implementation of the Android v4 In-app billi
 
 It supports: In-App Product Purchases (both non-consumable and consumable) and Subscriptions.
 
+**Keep in mind**, the library will provide the client side features necessary to implement in-app purchases but will still require quite a lot of work on your side. You'll also have to implement the server to validate your receipts (which is probably the most time consuming part to do correctly).
+
+If you're looking for a *Plug & Play* SDK that does everything (including the server validation of your receipts), you can use the [IAPHUB SDK](https://github.com/iaphub/iaphub-android-sdk).
+
 ## Maintainers Wanted
 
 This project is looking for maintainers. 


### PR DESCRIPTION
Hey @serggl,

I'm working hard on [iaphub-android-sdk](https://github.com/iaphub/iaphub-android-sdk), the idea is to make in-app purchase super easy by offering a SDK that does everything for the user (server validation of receipts included).

By looking at the issues I saw a lot of users struggling to implement IAP correctly and I thought it might be interesting for some of them to have an alternative if they are more looking for a 'Plug and Play' library to sell in-app purchases.

Thanks for the support 🙏 